### PR TITLE
Validate JSON object payload for event creation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -29,13 +29,16 @@ def error_response(status: int, message: str, details=None):
 
 def validate_event(data: dict):
     """Validate event data for creation/update operations.
-    
+
     Args:
         data (dict): Event data to validate.
-        
+
     Returns:
         tuple: (is_valid: bool, errors: dict)
     """
+    if not isinstance(data, dict):
+        return False, {"_schema": ["Objet JSON requis pour l'évènement."]}
+
     errors = {}
 
     title = data.get("title")
@@ -114,6 +117,12 @@ def create_event():
     data = request.get_json(silent=True)
     if data is None:
         return error_response(400, "JSON invalide ou non parsable.")
+
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON est requis.",
+        )
 
     is_valid, errors = validate_event(data)
     if not is_valid:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,3 +27,10 @@ def test_create_event(client):
     response = client.post('/events', json={"title": "Test Event"})
     assert response.status_code == 201
     assert 'event_id' in response.json
+
+
+def test_create_event_with_array_payload(client):
+    response = client.post('/events', json=[{"title": "Invalid"}])
+    assert response.status_code == 400
+    assert response.json['error']['code'] == 400
+    assert 'objet JSON' in response.json['error']['message']


### PR DESCRIPTION
## Summary
- ensure the create_event endpoint rejects non-object JSON payloads
- harden validate_event against non-dictionary data
- cover the behavior with a regression test for array payloads

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d78a6c809083329a524388b225d5cc