### PR TITLE
Add in-memory event storage and tests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,6 +10,44 @@ from datetime import datetime
 app = Flask(__name__)
 
 
+# In-memory storage for events. This mimics a lightweight persistence layer
+# for the purposes of the current application scope.
+_INITIAL_EVENTS = [
+    {
+        "id": 1,
+        "title": "Networking Night Paris",
+        "date": "2025-08-15",
+        "location": "Paris",
+        "type": "networking",
+        "attendees": 45,
+    },
+    {
+        "id": 2,
+        "title": "Tech Meetup Lyon",
+        "date": "2025-08-20",
+        "location": "Lyon",
+        "type": "tech",
+        "attendees": 32,
+    },
+]
+
+
+def _reset_events_storage():
+    """Reset the in-memory storage to its initial state."""
+    global _events_storage, _next_event_id
+    _events_storage = [event.copy() for event in _INITIAL_EVENTS]
+    _next_event_id = (
+        max(event["id"] for event in _events_storage) + 1
+        if _events_storage
+        else 1
+    )
+
+
+_events_storage = []
+_next_event_id = 1
+_reset_events_storage()
+
+
 def error_response(status: int, message: str, details=None):
     """Create a standardized error response.
     
@@ -69,25 +107,7 @@ def get_events():
     Returns:
         Response: JSON response with events list.
     """
-    events = [
-        {
-            "id": 1,
-            "title": "Networking Night Paris",
-            "date": "2025-08-15",
-            "location": "Paris",
-            "type": "networking",
-            "attendees": 45,
-        },
-        {
-            "id": 2,
-            "title": "Tech Meetup Lyon",
-            "date": "2025-08-20",
-            "location": "Lyon",
-            "type": "tech",
-            "attendees": 32,
-        },
-    ]
-    return jsonify({"events": events})
+    return jsonify({"events": [event.copy() for event in _events_storage]})
 
 
 @app.route("/events", methods=["POST"])
@@ -119,8 +139,10 @@ def create_event():
     if not is_valid:
         return error_response(422, "Validation échouée.", errors)
 
+    global _next_event_id
+
     new_event = {
-        "id": 123,  # TODO: replace with real ID from database
+        "id": _next_event_id,
         "title": data["title"].strip(),
         "date": data.get("date")
         or datetime.today().strftime("%Y-%m-%d"),
@@ -128,6 +150,9 @@ def create_event():
         "type": data.get("type") or "general",
         "attendees": data.get("attendees", 0),
     }
+
+    _events_storage.append(new_event)
+    _next_event_id += 1
 
     return (
         jsonify(
@@ -151,16 +176,15 @@ def get_event(event_id):
     Returns:
         Response: JSON response with event details.
     """
-    event = {
-        "id": event_id,
-        "title": "Sample Event",
-        "date": "2025-08-15",
-        "location": "Paris",
-        "description": (
-            "Networking event for professionals"
-        ),
-    }
-    return jsonify({"event": event})
+    event = next(
+        (stored_event for stored_event in _events_storage if stored_event["id"] == event_id),
+        None,
+    )
+
+    if event is None:
+        return error_response(404, "Événement introuvable.")
+
+    return jsonify({"event": event.copy()})
 
 
 @app.errorhandler(404)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,17 @@
+from pathlib import Path
+import sys
+
 import pytest
-from src.main import app
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.main import app, _reset_events_storage
 
 
 @pytest.fixture
 def client():
     app.config['TESTING'] = True
+    _reset_events_storage()
     with app.test_client() as client:
         yield client
 
@@ -27,3 +34,35 @@ def test_create_event(client):
     response = client.post('/events', json={"title": "Test Event"})
     assert response.status_code == 201
     assert 'event_id' in response.json
+
+
+def test_create_and_get_event(client):
+    payload = {
+        "title": "Evenement Test",
+        "date": "2025-09-01",
+        "location": "Marseille",
+        "type": "networking",
+        "attendees": 10,
+    }
+
+    create_response = client.post('/events', json=payload)
+    assert create_response.status_code == 201
+    event_id = create_response.json['event_id']
+
+    get_response = client.get(f'/events/{event_id}')
+    assert get_response.status_code == 200
+    event = get_response.json['event']
+    assert event['id'] == event_id
+    assert event['title'] == payload['title']
+    assert event['date'] == payload['date']
+    assert event['location'] == payload['location']
+    assert event['type'] == payload['type']
+    assert event['attendees'] == payload['attendees']
+
+
+def test_get_event_not_found(client):
+    response = client.get('/events/9999')
+    assert response.status_code == 404
+    error = response.json['error']
+    assert error['code'] == 404
+    assert error['message'] == 'Événement introuvable.'


### PR DESCRIPTION
## Summary
- introduce an in-memory storage layer for events with helper reset utility
- update event endpoints to use shared storage, generate IDs, and return 404 for missing events
- expand the test suite to cover event creation, retrieval, and missing IDs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d78a6da0b88332abccb034a596a55e