### PR TITLE
Reject boolean attendees counts

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -44,9 +44,13 @@ def validate_event(data: dict):
 
     if "attendees" in data:
         att = data["attendees"]
-        if not isinstance(att, int) or att < 0:
+        if (
+            not isinstance(att, int)
+            or isinstance(att, bool)
+            or att < 0
+        ):
             errors.setdefault("attendees", []).append(
-                "Doit être un entier >= 0."
+                "Doit être un entier non booléen >= 0."
             )
 
     return len(errors) == 0, errors

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -27,3 +27,12 @@ def test_create_event(client):
     response = client.post('/events', json={"title": "Test Event"})
     assert response.status_code == 201
     assert 'event_id' in response.json
+
+
+def test_create_event_rejects_boolean_attendees(client):
+    response = client.post('/events', json={"title": "Bool Event", "attendees": True})
+    assert response.status_code == 422
+    assert response.json["error"]["message"] == "Validation échouée."
+    assert response.json["error"]["details"]["attendees"] == [
+        "Doit être un entier non booléen >= 0."
+    ]


### PR DESCRIPTION
## Summary
- reject boolean attendee values during event payload validation
- clarify validation error messaging for attendee counts
- add regression test covering boolean attendee payload rejection

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d78a6fe33083328d5e41c6bdc0f1b4