### PR TITLE
Implement shared event storage for events API

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,16 @@
+from pathlib import Path
+import sys
+
 import pytest
-from src.main import app
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.main import app, _reset_events_storage
 
 
 @pytest.fixture
 def client():
+    _reset_events_storage()
     app.config['TESTING'] = True
     with app.test_client() as client:
         yield client


### PR DESCRIPTION
## Summary
- add module-level event storage seeded with sample events and backed by a counter-based ID generator
- persist creations into the shared storage and reuse it for collection and single-event lookups
- reset the storage between tests and cover create/retrieve and 404 scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d966565ef08332a717e58fa871fcec