### PR TITLE
Handle invalid event dates and add validation tests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -103,17 +103,23 @@ def validate_event(data: dict):
 
     if "date" in data:
         date_value = data.get("date")
-        if not isinstance(date_value, str) or not date_value.strip():
+        if not isinstance(date_value, str):
             errors.setdefault("date", []).append(
                 "Doit être une chaîne au format YYYY-MM-DD."
             )
         else:
-            try:
-                datetime.strptime(date_value.strip(), "%Y-%m-%d")
-            except ValueError:
+            stripped_date = date_value.strip()
+            if not stripped_date:
                 errors.setdefault("date", []).append(
-                    "Format de date invalide, attendu YYYY-MM-DD."
+                    "Doit être une chaîne au format YYYY-MM-DD."
                 )
+            else:
+                try:
+                    datetime.strptime(stripped_date, "%Y-%m-%d")
+                except ValueError:
+                    errors.setdefault("date", []).append(
+                        "Format de date invalide, attendu YYYY-MM-DD."
+                    )
 
     return len(errors) == 0, errors
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -29,6 +29,28 @@ def test_create_event(client):
     assert 'event_id' in response.json
 
 
+def test_create_event_with_invalid_date(client):
+    response = client.post(
+        '/events',
+        json={"title": "Date Invalide", "date": "2025/09/01"},
+    )
+    assert response.status_code == 422
+    error = response.json["error"]
+    assert error["message"] == "Validation échouée."
+    assert "date" in error["details"]
+    assert any(
+        "YYYY-MM-DD" in message for message in error["details"]["date"]
+    )
+
+
+def test_create_event_with_valid_date(client):
+    payload = {"title": "Date Valide", "date": "2025-10-05"}
+    response = client.post('/events', json=payload)
+    assert response.status_code == 201
+    created_event = response.json["event"]
+    assert created_event["date"] == payload["date"]
+
+
 def test_create_and_get_event(client):
     payload = {
         "title": "Evenement Test",


### PR DESCRIPTION
## Summary
- tighten event date validation to ensure provided strings parse with YYYY-MM-DD
- keep accepted dates intact when creating events and document behaviour with tests

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9667107c88332ac4e646f5f987220