### PR TITLE
Add catalog routes, template-based creation, and approval workflow

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,219 +1,44 @@
-"""Meetinity Event Service using SQLAlchemy for persistence."""
+"""Meetinity Event Service application entrypoint."""
+from __future__ import annotations
 
-from flask import Flask, jsonify, request, g
+from flask import Flask
 
-from src.database import get_session, init_engine
-from src.services.events import EventNotFoundError, EventService, ValidationError
+from src.database import init_engine
+from src.routes import register_blueprints
+from src.routes.dependencies import cleanup_services
+from src.routes.utils import error_response
 
 app = Flask(__name__)
 
 
-# Initialise the database engine using environment configuration.
-init_engine()
+def create_app() -> Flask:
+    init_engine()
+    register_blueprints(app)
+    app.teardown_appcontext(cleanup_services)
+    register_error_handlers(app)
+    return app
 
 
-def get_event_service() -> EventService:
-    """Return a lazily initialised :class:`EventService` for the request."""
-
-    if "db_session" not in g:
-        g.db_session = get_session()
-    if "event_service" not in g:
-        g.event_service = EventService(g.db_session)
-    return g.event_service
-
-
-@app.teardown_appcontext
-def shutdown_session(exception):
-    """Ensure the SQLAlchemy session is properly closed after each request."""
-
-    session = g.pop("db_session", None)
-    g.pop("event_service", None)
-    if session is not None:
-        try:
-            if exception is not None:
-                session.rollback()
-        finally:
-            session.close()
-
-
-def error_response(status: int, message: str, details=None):
-    """Create a standardized error response.
-
-    Args:
-        status (int): HTTP status code.
-        message (str): Error message.
-        details (dict, optional): Additional error details.
-
-    Returns:
-        tuple: JSON response and status code.
-    """
-    payload = {"error": {"code": status, "message": message}}
-    if details:
-        payload["error"]["details"] = details
-    return jsonify(payload), status
-
-
-@app.route("/health")
+@app.get("/health")
 def health():
-    """Health check endpoint.
-
-    Returns:
-        Response: JSON response with service status.
-    """
-    return jsonify({"status": "ok", "service": "event-service"})
+    return {"status": "ok", "service": "event-service"}
 
 
-@app.route("/events")
-def get_events():
-    """Retrieve list of available events with optional filters."""
+def register_error_handlers(flask_app: Flask) -> None:
+    @flask_app.errorhandler(404)
+    def handle_404(e):
+        return error_response(404, "Ressource introuvable.")
 
-    service = get_event_service()
+    @flask_app.errorhandler(405)
+    def handle_405(e):
+        return error_response(405, "Méthode non autorisée pour cette ressource.")
 
-    try:
-        events = service.list_events(
-            event_type=request.args.get("type"),
-            location=request.args.get("location"),
-            before=request.args.get("before"),
-            after=request.args.get("after"),
-        )
-    except ValidationError as exc:
-        return error_response(422, exc.message, exc.errors)
-
-    return jsonify({"events": events})
+    @flask_app.errorhandler(500)
+    def handle_500(e):
+        return error_response(500, "Erreur interne. On respire, on relance.")
 
 
-@app.route("/events", methods=["POST"])
-def create_event():
-    """Create a new professional event.
-
-    Expected JSON payload:
-        {
-            "title": str (required),
-            "date": str (optional),
-            "location": str (optional),
-            "type": str (optional),
-            "attendees": int (optional)
-        }
-
-    Returns:
-        Response: JSON response with created event details.
-    """
-    if not request.is_json:
-        return error_response(
-            415, "Content-Type 'application/json' requis."
-        )
-
-    data = request.get_json(silent=True)
-    if data is None:
-        return error_response(400, "JSON invalide ou non parsable.")
-
-    if not isinstance(data, dict):
-        return error_response(
-            400,
-            "Payload JSON invalide: un objet JSON (type dict) est requis.",
-        )
-
-    service = get_event_service()
-
-    try:
-        created_event = service.create_event(data)
-    except ValidationError as exc:
-        return error_response(422, exc.message, exc.errors)
-
-    payload = {
-        "message": "Event created",
-        "event_id": created_event["id"],
-        "event": created_event,
-    }
-    return jsonify(payload), 201
-
-
-@app.route("/events/<int:event_id>")
-def get_event(event_id):
-    """Retrieve details for a specific event.
-
-    Args:
-        event_id (int): The ID of the event to retrieve.
-
-    Returns:
-        Response: JSON response with event details.
-    """
-    service = get_event_service()
-
-    try:
-        event = service.get_event(event_id)
-    except EventNotFoundError:
-        return error_response(404, "Événement introuvable.")
-
-    return jsonify({"event": event})
-
-
-@app.route("/events/<int:event_id>", methods=["PATCH"])
-def update_event(event_id):
-    """Partially update an existing event."""
-
-    if not request.is_json:
-        return error_response(415, "Content-Type 'application/json' requis.")
-
-    data = request.get_json(silent=True)
-    if data is None:
-        return error_response(400, "JSON invalide ou non parsable.")
-
-    if not isinstance(data, dict):
-        return error_response(
-            400,
-            "Payload JSON invalide: un objet JSON (type dict) est requis.",
-        )
-
-    service = get_event_service()
-
-    try:
-        updated_event = service.update_event(event_id, data)
-    except EventNotFoundError:
-        return error_response(404, "Événement introuvable.")
-    except ValidationError as exc:
-        return error_response(422, exc.message, exc.errors)
-
-    return jsonify({"message": "Event updated", "event": updated_event})
-
-
-@app.errorhandler(404)
-def handle_404(e):
-    """Handle 404 Not Found errors.
-
-    Args:
-        e: The error object.
-
-    Returns:
-        Response: Standardized 404 error response.
-    """
-    return error_response(404, "Ressource introuvable.")
-
-
-@app.errorhandler(405)
-def handle_405(e):
-    """Handle 405 Method Not Allowed errors.
-
-    Args:
-        e: The error object.
-
-    Returns:
-        Response: Standardized 405 error response.
-    """
-    return error_response(405, "Méthode non autorisée pour cette ressource.")
-
-
-@app.errorhandler(500)
-def handle_500(e):
-    """Handle 500 Internal Server Error.
-
-    Args:
-        e: The error object.
-
-    Returns:
-        Response: Standardized 500 error response.
-    """
-    return error_response(500, "Erreur interne. On respire, on relance.")
+create_app()
 
 
 if __name__ == "__main__":

--- a/src/repositories/catalogs.py
+++ b/src/repositories/catalogs.py
@@ -1,0 +1,252 @@
+"""Repository helpers for taxonomies and templates."""
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import NoResultFound
+from sqlalchemy.orm import Session, joinedload
+
+from src.models import (
+    EventCategory,
+    EventSeries,
+    EventTag,
+    EventTemplate,
+    EventTemplateTranslation,
+)
+
+__all__ = [
+    "CategoryRepository",
+    "TagRepository",
+    "SeriesRepository",
+    "TemplateRepository",
+]
+
+
+class BaseRepository:
+    """Base repository storing the SQLAlchemy session."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+
+class CategoryRepository(BaseRepository):
+    """Repository for :class:`EventCategory`."""
+
+    def list(self) -> Sequence[EventCategory]:
+        query = select(EventCategory).order_by(EventCategory.name.asc())
+        return self.session.scalars(query).all()
+
+    def get(self, category_id: int) -> EventCategory:
+        category = self.session.get(EventCategory, category_id)
+        if category is None:
+            raise LookupError(f"Category {category_id} not found")
+        return category
+
+    def create(self, *, name: str, description: Optional[str]) -> EventCategory:
+        category = EventCategory(name=name, description=description)
+        self.session.add(category)
+        self.session.flush()
+        self.session.refresh(category)
+        return category
+
+    def delete(self, category: EventCategory) -> None:
+        self.session.delete(category)
+
+    def update(self, category: EventCategory, *, name: Optional[str], description: Optional[str]) -> EventCategory:
+        if name is not None:
+            category.name = name
+        if description is not None:
+            category.description = description
+        self.session.flush()
+        self.session.refresh(category)
+        return category
+
+
+class TagRepository(BaseRepository):
+    """Repository for :class:`EventTag`."""
+
+    def list(self) -> Sequence[EventTag]:
+        query = select(EventTag).order_by(EventTag.name.asc())
+        return self.session.scalars(query).all()
+
+    def get(self, tag_id: int) -> EventTag:
+        tag = self.session.get(EventTag, tag_id)
+        if tag is None:
+            raise LookupError(f"Tag {tag_id} not found")
+        return tag
+
+    def create(self, *, name: str) -> EventTag:
+        tag = EventTag(name=name)
+        self.session.add(tag)
+        self.session.flush()
+        self.session.refresh(tag)
+        return tag
+
+    def delete(self, tag: EventTag) -> None:
+        self.session.delete(tag)
+
+    def update(self, tag: EventTag, *, name: Optional[str]) -> EventTag:
+        if name is not None:
+            tag.name = name
+        self.session.flush()
+        self.session.refresh(tag)
+        return tag
+
+
+class SeriesRepository(BaseRepository):
+    """Repository for :class:`EventSeries`."""
+
+    def list(self) -> Sequence[EventSeries]:
+        query = select(EventSeries).order_by(EventSeries.name.asc())
+        return self.session.scalars(query).all()
+
+    def get(self, series_id: int) -> EventSeries:
+        series = self.session.get(EventSeries, series_id)
+        if series is None:
+            raise LookupError(f"Series {series_id} not found")
+        return series
+
+    def get_by_name(self, name: str) -> Optional[EventSeries]:
+        query = select(EventSeries).where(func.lower(EventSeries.name) == name.casefold())
+        return self.session.scalars(query).first()
+
+    def create(self, *, name: str, description: Optional[str]) -> EventSeries:
+        series = EventSeries(name=name, description=description)
+        self.session.add(series)
+        self.session.flush()
+        self.session.refresh(series)
+        return series
+
+    def update(self, series: EventSeries, *, name: Optional[str], description: Optional[str]) -> EventSeries:
+        if name is not None:
+            series.name = name
+        if description is not None:
+            series.description = description
+        self.session.flush()
+        self.session.refresh(series)
+        return series
+
+    def delete(self, series: EventSeries) -> None:
+        self.session.delete(series)
+
+
+class TemplateRepository(BaseRepository):
+    """Repository for :class:`EventTemplate`."""
+
+    def list(self) -> Sequence[EventTemplate]:
+        query = (
+            select(EventTemplate)
+            .options(joinedload(EventTemplate.translations))
+            .order_by(EventTemplate.name.asc())
+        )
+        return self.session.scalars(query).all()
+
+    def get(self, template_id: int) -> EventTemplate:
+        query = (
+            select(EventTemplate)
+            .options(joinedload(EventTemplate.translations))
+            .where(EventTemplate.id == template_id)
+        )
+        try:
+            return self.session.execute(query).scalar_one()
+        except NoResultFound as exc:
+            raise LookupError(f"Template {template_id} not found") from exc
+
+    def get_by_name(self, name: str) -> Optional<EventTemplate]:
+        query = select(EventTemplate).where(EventTemplate.name == name)
+        return self.session.scalars(query).first()
+
+    def create(
+        self,
+        *,
+        name: str,
+        description: Optional[str],
+        default_duration_minutes: Optional[int],
+        default_timezone: str,
+        default_locale: str,
+        fallback_locale: Optional[str],
+        default_capacity_limit: Optional[int],
+        default_metadata: Optional[dict],
+    ) -> EventTemplate:
+        template = EventTemplate(
+            name=name,
+            description=description,
+            default_duration_minutes=default_duration_minutes,
+            default_timezone=default_timezone,
+            default_locale=default_locale,
+            fallback_locale=fallback_locale,
+            default_capacity_limit=default_capacity_limit,
+            default_metadata=default_metadata,
+        )
+        self.session.add(template)
+        self.session.flush()
+        self.session.refresh(template)
+        return template
+
+    def update(
+        self,
+        template: EventTemplate,
+        *,
+        description: Optional[str],
+        default_duration_minutes: Optional[int],
+        default_timezone: Optional[str],
+        default_locale: Optional[str],
+        fallback_locale: Optional[str],
+        default_capacity_limit: Optional[int],
+        default_metadata: Optional[dict],
+    ) -> EventTemplate:
+        if description is not None:
+            template.description = description
+        if default_duration_minutes is not None:
+            template.default_duration_minutes = default_duration_minutes
+        if default_timezone is not None:
+            template.default_timezone = default_timezone
+        if default_locale is not None:
+            template.default_locale = default_locale
+        if fallback_locale is not None or fallback_locale == "":
+            template.fallback_locale = fallback_locale or None
+        if default_capacity_limit is not None or default_capacity_limit == 0:
+            template.default_capacity_limit = default_capacity_limit
+        if default_metadata is not None:
+            template.default_metadata = default_metadata
+        self.session.flush()
+        self.session.refresh(template)
+        return template
+
+    def delete(self, template: EventTemplate) -> None:
+        self.session.delete(template)
+
+    def upsert_translation(
+        self,
+        template: EventTemplate,
+        *,
+        locale: str,
+        title: str,
+        description: Optional[str],
+    ) -> EventTemplateTranslation:
+        translation = next(
+            (t for t in template.translations if t.locale == locale),
+            None,
+        )
+        if translation is None:
+            translation = EventTemplateTranslation(
+                template=template,
+                locale=locale,
+                title=title,
+                description=description,
+            )
+            self.session.add(translation)
+        else:
+            translation.title = title
+            translation.description = description
+        self.session.flush()
+        self.session.refresh(translation)
+        return translation
+
+    def remove_translation(self, template: EventTemplate, locale: str) -> None:
+        translation = next((t for t in template.translations if t.locale == locale), None)
+        if translation is None:
+            raise LookupError(f"Translation {locale} not found for template {template.id}")
+        self.session.delete(translation)
+

--- a/src/repositories/events.py
+++ b/src/repositories/events.py
@@ -2,13 +2,22 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Optional, Sequence
+from typing import Iterable, Optional, Sequence
 
 from sqlalchemy import func, select
 from sqlalchemy.exc import NoResultFound
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, joinedload, selectinload
 
-from src.models import Event, EventSeries
+from src.models import (
+    Event,
+    EventApprovalLog,
+    EventCategory,
+    EventNotification,
+    EventSeries,
+    EventTag,
+    EventTemplate,
+    EventTranslation,
+)
 
 
 class EventRepository:
@@ -24,10 +33,16 @@ class EventRepository:
         location: Optional[str] = None,
         before: Optional[date] = None,
         after: Optional[date] = None,
+        status: Optional[str] = None,
     ) -> Sequence[Event]:
         query = (
             select(Event)
-            .options(joinedload(Event.series))
+            .options(
+                joinedload(Event.series),
+                selectinload(Event.categories),
+                selectinload(Event.tags),
+                selectinload(Event.translations),
+            )
             .order_by(Event.event_date.asc(), Event.id.asc())
         )
 
@@ -39,13 +54,20 @@ class EventRepository:
             query = query.where(Event.event_date <= before)
         if after:
             query = query.where(Event.event_date >= after)
+        if status:
+            query = query.where(Event.status == status)
 
         return self.session.scalars(query).all()
 
     def get_event(self, event_id: int) -> Event:
         query = (
             select(Event)
-            .options(joinedload(Event.series))
+            .options(
+                joinedload(Event.series),
+                selectinload(Event.categories),
+                selectinload(Event.tags),
+                selectinload(Event.translations),
+            )
             .where(Event.id == event_id)
         )
         try:
@@ -61,7 +83,18 @@ class EventRepository:
         location: Optional[str],
         event_type: Optional[str],
         attendees: int,
+        timezone: str,
+        status: str,
+        capacity_limit: Optional[int],
+        recurrence_rule: Optional[str],
+        default_locale: str,
+        fallback_locale: Optional[str],
+        organizer_email: Optional[str],
+        settings: Optional[dict],
         series: Optional[EventSeries] = None,
+        template: Optional[EventTemplate] = None,
+        categories: Optional[Iterable[EventCategory]] = None,
+        tags: Optional[Iterable[EventTag]] = None,
     ) -> Event:
         event = Event(
             title=title,
@@ -69,9 +102,23 @@ class EventRepository:
             location=location,
             event_type=event_type,
             attendees=attendees,
+            timezone=timezone,
+            status=status,
+            capacity_limit=capacity_limit,
+            recurrence_rule=recurrence_rule,
+            default_locale=default_locale,
+            fallback_locale=fallback_locale,
+            organizer_email=organizer_email,
+            settings=settings,
         )
         if series:
             event.series = series
+        if template:
+            event.template = template
+        if categories:
+            event.categories = list(categories)
+        if tags:
+            event.tags = list(tags)
 
         self.session.add(event)
         self.session.flush()
@@ -85,24 +132,104 @@ class EventRepository:
         self.session.refresh(event)
         return event
 
-    def get_or_create_series(self, name: str) -> EventSeries:
-        query = select(EventSeries).where(func.lower(EventSeries.name) == name.casefold())
-        result = self.session.scalars(query).first()
-        if result:
-            return result
-
-        series = EventSeries(name=name.strip())
-        self.session.add(series)
-        self.session.flush()
-        self.session.refresh(series)
-        return series
-
-    def get_series_by_id(self, series_id: int) -> Optional[EventSeries]:
-        return self.session.get(EventSeries, series_id)
-
     def assign_series(self, event: Event, series: Optional[EventSeries]) -> None:
         event.series = series
         self.session.flush()
+
+    def assign_categories(
+        self, event: Event, categories: Iterable[EventCategory]
+    ) -> Event:
+        event.categories = list(categories)
+        self.session.flush()
+        self.session.refresh(event)
+        return event
+
+    def assign_tags(self, event: Event, tags: Iterable[EventTag]) -> Event:
+        event.tags = list(tags)
+        self.session.flush()
+        self.session.refresh(event)
+        return event
+
+    def upsert_translation(
+        self,
+        event: Event,
+        *,
+        locale: str,
+        title: str,
+        description: Optional[str],
+        fallback: Optional[bool],
+    ) -> EventTranslation:
+        translation = next(
+            (t for t in event.translations if t.locale == locale),
+            None,
+        )
+        if translation is None:
+            translation = EventTranslation(
+                event=event,
+                locale=locale,
+                title=title,
+                description=description,
+            )
+            self.session.add(translation)
+        else:
+            translation.title = title
+            translation.description = description
+        if fallback is True:
+            event.fallback_locale = locale
+        elif fallback is False and event.fallback_locale == locale:
+            event.fallback_locale = None
+        self.session.flush()
+        self.session.refresh(translation)
+        return translation
+
+    def remove_translation(self, event: Event, locale: str) -> None:
+        translation = next((t for t in event.translations if t.locale == locale), None)
+        if translation is None:
+            raise LookupError(f"Translation {locale} not found for event {event.id}")
+        self.session.delete(translation)
+        if event.fallback_locale == locale:
+            event.fallback_locale = None
+
+    def log_status_change(
+        self,
+        event: Event,
+        *,
+        previous_status: Optional[str],
+        new_status: str,
+        actor: Optional[str],
+        notes: Optional[str],
+    ) -> EventApprovalLog:
+        log = EventApprovalLog(
+            event=event,
+            previous_status=previous_status,
+            new_status=new_status,
+            actor=actor,
+            notes=notes,
+        )
+        self.session.add(log)
+        event.status = new_status
+        self.session.flush()
+        self.session.refresh(log)
+        return log
+
+    def create_notification(
+        self,
+        event: Event,
+        *,
+        recipient: str,
+        message: str,
+        channel: str = "email",
+    ) -> EventNotification:
+        notification = EventNotification(
+            event=event,
+            recipient=recipient,
+            message=message,
+            channel=channel,
+        )
+        self.session.add(notification)
+        self.session.flush()
+        self.session.refresh(notification)
+        return notification
 
     def remove_event(self, event: Event) -> None:
         self.session.delete(event)

--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -1,0 +1,20 @@
+"""Blueprint registration helpers."""
+from __future__ import annotations
+
+from flask import Flask
+
+from .event_categories import categories_bp
+from .event_series import series_bp
+from .event_tags import tags_bp
+from .event_templates import templates_bp
+from .events import events_bp
+
+__all__ = ["register_blueprints"]
+
+
+def register_blueprints(app: Flask) -> None:
+    app.register_blueprint(events_bp)
+    app.register_blueprint(categories_bp)
+    app.register_blueprint(tags_bp)
+    app.register_blueprint(series_bp)
+    app.register_blueprint(templates_bp)

--- a/src/routes/dependencies.py
+++ b/src/routes/dependencies.py
@@ -1,0 +1,70 @@
+"""Utilities for accessing services within Flask request context."""
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Type, TypeVar
+
+from flask import g
+
+from src.database import get_session
+from src.services.events import (
+    CategoryService,
+    EventService,
+    SeriesService,
+    TagService,
+    TemplateService,
+)
+
+T = TypeVar("T")
+
+SERVICE_FACTORIES: Dict[str, Callable[[Any], Any]] = {
+    "event_service": EventService,
+    "category_service": CategoryService,
+    "tag_service": TagService,
+    "series_service": SeriesService,
+    "template_service": TemplateService,
+}
+
+
+def get_db_session():
+    if "db_session" not in g:
+        g.db_session = get_session()
+    return g.db_session
+
+
+def get_event_service() -> EventService:
+    return _get_service("event_service", EventService)
+
+
+def get_category_service() -> CategoryService:
+    return _get_service("category_service", CategoryService)
+
+
+def get_tag_service() -> TagService:
+    return _get_service("tag_service", TagService)
+
+
+def get_series_service() -> SeriesService:
+    return _get_service("series_service", SeriesService)
+
+
+def get_template_service() -> TemplateService:
+    return _get_service("template_service", TemplateService)
+
+
+def _get_service(key: str, factory: Type[T]) -> T:
+    if key not in g:
+        session = get_db_session()
+        g[key] = factory(session)
+    return g[key]
+
+
+def cleanup_services(exception):
+    session = g.pop("db_session", None)
+    for key in list(SERVICE_FACTORIES.keys()):
+        g.pop(key, None)
+    if session is not None:
+        try:
+            if exception is not None:
+                session.rollback()
+        finally:
+            session.close()

--- a/src/routes/event_categories.py
+++ b/src/routes/event_categories.py
@@ -1,0 +1,78 @@
+"""Routes for managing event categories."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from src.routes.dependencies import get_category_service
+from src.routes.utils import error_response
+from src.services.events import ValidationError
+
+categories_bp = Blueprint("event_categories", __name__)
+
+
+@categories_bp.get("/event-categories")
+def list_categories():
+    service = get_category_service()
+    categories = service.list_categories()
+    return jsonify({"categories": categories})
+
+
+@categories_bp.post("/event-categories")
+def create_category():
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    service = get_category_service()
+    try:
+        category = service.create_category(data)
+    except ValidationError as exc:
+        return error_response(422, exc.message, exc.errors)
+    return jsonify({"category": category}), 201
+
+
+@categories_bp.get("/event-categories/<int:category_id>")
+def get_category(category_id: int):
+    service = get_category_service()
+    try:
+        category = service.get_category(category_id)
+    except ValidationError as exc:
+        return error_response(404, exc.message, exc.errors)
+    return jsonify({"category": category})
+
+
+@categories_bp.route("/event-categories/<int:category_id>", methods=["PUT", "PATCH"])
+def update_category(category_id: int):
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    service = get_category_service()
+    try:
+        category = service.update_category(category_id, data)
+    except ValidationError as exc:
+        code = 404 if "id" in exc.errors else 422
+        return error_response(code, exc.message, exc.errors)
+    return jsonify({"category": category})
+
+
+@categories_bp.delete("/event-categories/<int:category_id>")
+def delete_category(category_id: int):
+    service = get_category_service()
+    try:
+        service.delete_category(category_id)
+    except ValidationError as exc:
+        return error_response(404, exc.message, exc.errors)
+    return ("", 204)

--- a/src/routes/event_series.py
+++ b/src/routes/event_series.py
@@ -1,0 +1,78 @@
+"""Routes for managing event series."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from src.routes.dependencies import get_series_service
+from src.routes.utils import error_response
+from src.services.events import ValidationError
+
+series_bp = Blueprint("event_series", __name__)
+
+
+@series_bp.get("/event-series")
+def list_series():
+    service = get_series_service()
+    series = service.list_series()
+    return jsonify({"series": series})
+
+
+@series_bp.post("/event-series")
+def create_series():
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    service = get_series_service()
+    try:
+        series = service.create_series(data)
+    except ValidationError as exc:
+        return error_response(422, exc.message, exc.errors)
+    return jsonify({"series": series}), 201
+
+
+@series_bp.get("/event-series/<int:series_id>")
+def get_series(series_id: int):
+    service = get_series_service()
+    try:
+        series = service.get_series(series_id)
+    except ValidationError as exc:
+        return error_response(404, exc.message, exc.errors)
+    return jsonify({"series": series})
+
+
+@series_bp.route("/event-series/<int:series_id>", methods=["PUT", "PATCH"])
+def update_series(series_id: int):
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    service = get_series_service()
+    try:
+        series = service.update_series(series_id, data)
+    except ValidationError as exc:
+        code = 404 if "id" in exc.errors else 422
+        return error_response(code, exc.message, exc.errors)
+    return jsonify({"series": series})
+
+
+@series_bp.delete("/event-series/<int:series_id>")
+def delete_series(series_id: int):
+    service = get_series_service()
+    try:
+        service.delete_series(series_id)
+    except ValidationError as exc:
+        return error_response(404, exc.message, exc.errors)
+    return ("", 204)

--- a/src/routes/event_tags.py
+++ b/src/routes/event_tags.py
@@ -1,0 +1,78 @@
+"""Routes for managing event tags."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from src.routes.dependencies import get_tag_service
+from src.routes.utils import error_response
+from src.services.events import ValidationError
+
+tags_bp = Blueprint("event_tags", __name__)
+
+
+@tags_bp.get("/event-tags")
+def list_tags():
+    service = get_tag_service()
+    tags = service.list_tags()
+    return jsonify({"tags": tags})
+
+
+@tags_bp.post("/event-tags")
+def create_tag():
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    service = get_tag_service()
+    try:
+        tag = service.create_tag(data)
+    except ValidationError as exc:
+        return error_response(422, exc.message, exc.errors)
+    return jsonify({"tag": tag}), 201
+
+
+@tags_bp.get("/event-tags/<int:tag_id>")
+def get_tag(tag_id: int):
+    service = get_tag_service()
+    try:
+        tag = service.get_tag(tag_id)
+    except ValidationError as exc:
+        return error_response(404, exc.message, exc.errors)
+    return jsonify({"tag": tag})
+
+
+@tags_bp.route("/event-tags/<int:tag_id>", methods=["PUT", "PATCH"])
+def update_tag(tag_id: int):
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    service = get_tag_service()
+    try:
+        tag = service.update_tag(tag_id, data)
+    except ValidationError as exc:
+        code = 404 if "id" in exc.errors else 422
+        return error_response(code, exc.message, exc.errors)
+    return jsonify({"tag": tag})
+
+
+@tags_bp.delete("/event-tags/<int:tag_id>")
+def delete_tag(tag_id: int):
+    service = get_tag_service()
+    try:
+        service.delete_tag(tag_id)
+    except ValidationError as exc:
+        return error_response(404, exc.message, exc.errors)
+    return ("", 204)

--- a/src/routes/event_templates.py
+++ b/src/routes/event_templates.py
@@ -1,0 +1,132 @@
+"""Routes for managing event templates."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from src.routes.dependencies import get_template_service
+from src.routes.utils import error_response
+from src.services.events import ValidationError
+
+templates_bp = Blueprint("event_templates", __name__)
+
+
+@templates_bp.get("/event-templates")
+def list_templates():
+    service = get_template_service()
+    templates = service.list_templates()
+    return jsonify({"templates": templates})
+
+
+@templates_bp.post("/event-templates")
+def create_template():
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    service = get_template_service()
+    try:
+        template = service.create_template(data)
+    except ValidationError as exc:
+        return error_response(422, exc.message, exc.errors)
+    return jsonify({"template": template}), 201
+
+
+@templates_bp.get("/event-templates/<int:template_id>")
+def get_template(template_id: int):
+    service = get_template_service()
+    try:
+        template = service.get_template(template_id)
+    except ValidationError as exc:
+        return error_response(404, exc.message, exc.errors)
+    return jsonify({"template": template})
+
+
+@templates_bp.route("/event-templates/<int:template_id>", methods=["PUT", "PATCH"])
+def update_template(template_id: int):
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    service = get_template_service()
+    try:
+        template = service.update_template(template_id, data)
+    except ValidationError as exc:
+        code = 404 if "id" in exc.errors else 422
+        return error_response(code, exc.message, exc.errors)
+    return jsonify({"template": template})
+
+
+@templates_bp.delete("/event-templates/<int:template_id>")
+def delete_template(template_id: int):
+    service = get_template_service()
+    try:
+        service.delete_template(template_id)
+    except ValidationError as exc:
+        return error_response(404, exc.message, exc.errors)
+    return ("", 204)
+
+
+@templates_bp.post("/event-templates/<int:template_id>/translations")
+def add_template_translation(template_id: int):
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    service = get_template_service()
+    try:
+        translation = service.upsert_translation(template_id, data)
+    except ValidationError as exc:
+        code = 404 if "id" in exc.errors else 422
+        return error_response(code, exc.message, exc.errors)
+    return jsonify({"translation": translation}), 201
+
+
+@templates_bp.put("/event-templates/<int:template_id>/translations/<locale>")
+def update_template_translation(template_id: int, locale: str):
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    data.setdefault("locale", locale)
+    service = get_template_service()
+    try:
+        translation = service.upsert_translation(template_id, data)
+    except ValidationError as exc:
+        code = 404 if "id" in exc.errors else 422
+        return error_response(code, exc.message, exc.errors)
+    return jsonify({"translation": translation})
+
+
+@templates_bp.delete("/event-templates/<int:template_id>/translations/<locale>")
+def delete_template_translation(template_id: int, locale: str):
+    service = get_template_service()
+    try:
+        service.delete_translation(template_id, locale)
+    except ValidationError as exc:
+        code = 404 if "id" in exc.errors else 422
+        return error_response(code, exc.message, exc.errors)
+    return ("", 204)

--- a/src/routes/events.py
+++ b/src/routes/events.py
@@ -1,0 +1,227 @@
+"""Routes for managing events and related workflows."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from src.routes.dependencies import get_event_service
+from src.routes.utils import error_response
+from src.services.events import (
+    ApprovalWorkflowError,
+    EventNotFoundError,
+    ValidationError,
+)
+
+events_bp = Blueprint("events", __name__)
+
+
+@events_bp.get("/events")
+def list_events():
+    service = get_event_service()
+    try:
+        events = service.list_events(
+            event_type=request.args.get("type"),
+            location=request.args.get("location"),
+            before=request.args.get("before"),
+            after=request.args.get("after"),
+            status=request.args.get("status"),
+        )
+    except ValidationError as exc:
+        return error_response(422, exc.message, exc.errors)
+    return jsonify({"events": events})
+
+
+@events_bp.post("/events")
+def create_event():
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+
+    service = get_event_service()
+    try:
+        created_event = service.create_event(data)
+    except ValidationError as exc:
+        return error_response(422, exc.message, exc.errors)
+
+    payload = {
+        "message": "Event created",
+        "event_id": created_event["id"],
+        "event": created_event,
+    }
+    return jsonify(payload), 201
+
+
+@events_bp.get("/events/<int:event_id>")
+def get_event(event_id: int):
+    service = get_event_service()
+    try:
+        event = service.get_event(event_id)
+    except EventNotFoundError:
+        return error_response(404, "Événement introuvable.")
+    return jsonify({"event": event})
+
+
+@events_bp.patch("/events/<int:event_id>")
+def update_event(event_id: int):
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+
+    service = get_event_service()
+    try:
+        updated_event = service.update_event(event_id, data)
+    except EventNotFoundError:
+        return error_response(404, "Événement introuvable.")
+    except ValidationError as exc:
+        return error_response(422, exc.message, exc.errors)
+
+    return jsonify({"message": "Event updated", "event": updated_event})
+
+
+@events_bp.post("/events/from-template")
+def create_event_from_template():
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    template_id = data.get("template_id")
+    overrides = data.get("overrides", {})
+    if not isinstance(template_id, int) or template_id <= 0:
+        return error_response(422, "template_id doit être un entier positif.")
+    if not isinstance(overrides, dict):
+        return error_response(422, "overrides doit être un objet JSON.")
+
+    service = get_event_service()
+    try:
+        created_event = service.create_event_from_template(template_id, overrides)
+    except ValidationError as exc:
+        return error_response(422, exc.message, exc.errors)
+
+    payload = {
+        "message": "Event created from template",
+        "event_id": created_event["id"],
+        "event": created_event,
+    }
+    return jsonify(payload), 201
+
+
+@events_bp.post("/events/<int:event_id>/translations")
+def add_translation(event_id: int):
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    service = get_event_service()
+    try:
+        translation = service.upsert_translation(event_id, data)
+    except EventNotFoundError:
+        return error_response(404, "Événement introuvable.")
+    except ValidationError as exc:
+        return error_response(422, exc.message, exc.errors)
+    return jsonify({"translation": translation}), 201
+
+
+@events_bp.put("/events/<int:event_id>/translations/<locale>")
+def update_translation(event_id: int, locale: str):
+    if not request.is_json:
+        return error_response(415, "Content-Type 'application/json' requis.")
+    data = request.get_json(silent=True)
+    if data is None:
+        return error_response(400, "JSON invalide ou non parsable.")
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    data.setdefault("locale", locale)
+    service = get_event_service()
+    try:
+        translation = service.upsert_translation(event_id, data)
+    except EventNotFoundError:
+        return error_response(404, "Événement introuvable.")
+    except ValidationError as exc:
+        return error_response(422, exc.message, exc.errors)
+    return jsonify({"translation": translation})
+
+
+@events_bp.delete("/events/<int:event_id>/translations/<locale>")
+def delete_translation(event_id: int, locale: str):
+    service = get_event_service()
+    try:
+        service.delete_translation(event_id, locale)
+    except EventNotFoundError:
+        return error_response(404, "Événement introuvable.")
+    except ValidationError as exc:
+        return error_response(422, exc.message, exc.errors)
+    return ("", 204)
+
+
+def _handle_workflow(event_id: int, action: str):
+    if request.is_json:
+        data = request.get_json(silent=True) or {}
+    else:
+        data = {}
+    if not isinstance(data, dict):
+        return error_response(
+            400,
+            "Payload JSON invalide: un objet JSON (type dict) est requis.",
+        )
+    actor = data.get("actor")
+    notes = data.get("notes")
+    service = get_event_service()
+    try:
+        if action == "submit":
+            result = service.submit_for_approval(event_id, actor, notes)
+        elif action == "approve":
+            result = service.approve_event(event_id, actor, notes)
+        elif action == "reject":
+            result = service.reject_event(event_id, actor, notes)
+        else:
+            return error_response(400, "Action de workflow inconnue.")
+    except EventNotFoundError:
+        return error_response(404, "Événement introuvable.")
+    except ApprovalWorkflowError as exc:
+        return error_response(409, str(exc))
+    return jsonify(result)
+
+
+@events_bp.post("/events/<int:event_id>/submit")
+def submit_event(event_id: int):
+    return _handle_workflow(event_id, "submit")
+
+
+@events_bp.post("/events/<int:event_id>/approve")
+def approve_event(event_id: int):
+    return _handle_workflow(event_id, "approve")
+
+
+@events_bp.post("/events/<int:event_id>/reject")
+def reject_event(event_id: int):
+    return _handle_workflow(event_id, "reject")

--- a/src/routes/utils.py
+++ b/src/routes/utils.py
@@ -1,0 +1,13 @@
+"""Shared route utilities."""
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from flask import jsonify
+
+
+def error_response(status: int, message: str, details: Optional[Any] = None):
+    payload = {"error": {"code": status, "message": message}}
+    if details is not None:
+        payload["error"]["details"] = details
+    return jsonify(payload), status

--- a/src/services/events.py
+++ b/src/services/events.py
@@ -1,18 +1,86 @@
 """Service layer for event orchestration and validation."""
 from __future__ import annotations
 
+import copy
+import re
 from datetime import date, datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy.orm import Session
 
+from src.models import EventCategory, EventSeries, EventTag
+from src.repositories.catalogs import (
+    CategoryRepository,
+    SeriesRepository,
+    TagRepository,
+    TemplateRepository,
+)
 from src.repositories.events import EventRepository
 
 __all__ = [
+    "ApprovalWorkflowError",
     "EventNotFoundError",
     "EventService",
     "ValidationError",
+    "CategoryService",
+    "TagService",
+    "SeriesService",
+    "TemplateService",
 ]
+
+
+LOCALE_PATTERN = re.compile(r"^[a-z]{2}(?:[-_][A-Z]{2})?$")
+EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+ALLOWED_STATUSES = {"draft", "pending", "approved", "rejected"}
+
+
+def is_valid_locale(value: str) -> bool:
+    return bool(isinstance(value, str) and LOCALE_PATTERN.match(value))
+
+
+def validate_translation_payload(
+    payload: Dict[str, Any], *, require_locale: bool
+) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValidationError({"_schema": ["Traduction invalide (objet attendu)."]})
+
+    errors: Dict[str, List[str]] = {}
+    clean: Dict[str, Any] = {}
+
+    if "locale" in payload or require_locale:
+        locale = payload.get("locale")
+        if not isinstance(locale, str) or not is_valid_locale(locale):
+            errors.setdefault("locale", []).append("Locale invalide.")
+        else:
+            clean["locale"] = locale.replace("_", "-")
+
+    if "title" in payload or require_locale:
+        title = payload.get("title")
+        if not isinstance(title, str) or not title.strip():
+            errors.setdefault("title", []).append("Titre requis pour la traduction.")
+        else:
+            clean["title"] = title.strip()
+
+    if "description" in payload:
+        description = payload.get("description")
+        if description is not None and not isinstance(description, str):
+            errors.setdefault("description", []).append("Description invalide.")
+        else:
+            clean["description"] = description
+
+    if "fallback" in payload:
+        fallback = payload.get("fallback")
+        if not isinstance(fallback, bool):
+            errors.setdefault("fallback", []).append("Doit être un booléen.")
+        else:
+            clean["fallback"] = fallback
+
+    if errors:
+        raise ValidationError(errors)
+
+    return clean
 
 
 class ValidationError(Exception):
@@ -22,6 +90,13 @@ class ValidationError(Exception):
         super().__init__(message)
         self.errors = errors
         self.message = message
+
+
+class ApprovalWorkflowError(Exception):
+    """Raised when an invalid status transition is requested."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
 
 
 class EventNotFoundError(Exception):
@@ -34,6 +109,10 @@ class EventService:
     def __init__(self, session: Session) -> None:
         self.session = session
         self.repository = EventRepository(session)
+        self.category_repository = CategoryRepository(session)
+        self.tag_repository = TagRepository(session)
+        self.series_repository = SeriesRepository(session)
+        self.template_repository = TemplateRepository(session)
 
     # ------------------------------------------------------------------
     # Public API
@@ -45,11 +124,16 @@ class EventService:
         location: Optional[str] = None,
         before: Optional[str] = None,
         after: Optional[str] = None,
+        status: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         cleaned_type = self._normalize_filter_value(event_type)
         cleaned_location = self._normalize_filter_value(location)
         before_value = self._normalize_filter_value(before)
         after_value = self._normalize_filter_value(after)
+        status_value = self._normalize_filter_value(status)
+
+        if status_value and status_value not in ALLOWED_STATUSES:
+            raise ValidationError({"status": ["Statut inconnu."]})
 
         before_date = self._parse_filter_date(before_value, "before")
         after_date = self._parse_filter_date(after_value, "after")
@@ -59,6 +143,7 @@ class EventService:
             location=cleaned_location,
             before=before_date,
             after=after_date,
+            status=status_value,
         )
         return [self._serialize_event(event) for event in events]
 
@@ -73,17 +158,49 @@ class EventService:
         clean_payload = self._validate_event_payload(payload, require_title=True)
 
         event_date = clean_payload.pop("event_date", date.today())
-        series = None
-        series_name = clean_payload.pop("series_name", None)
-        series_id = clean_payload.pop("series_id", None)
-        if series_id is not None:
-            series = self.repository.get_series_by_id(series_id)
-            if series is None:
-                raise ValidationError({"series_id": ["Série introuvable."]})
-        elif series_name:
-            series = self.repository.get_or_create_series(series_name)
+        series = self._resolve_series(clean_payload)
+        categories = self._resolve_categories(clean_payload)
+        tags = self._resolve_tags(clean_payload)
+        translations = clean_payload.pop("translations", [])
+        clean_payload.pop("_series_specified", None)
+        clean_payload.pop("_categories_specified", None)
+        clean_payload.pop("_tags_specified", None)
 
-        event = self.repository.create_event(series=series, event_date=event_date, **clean_payload)
+        event = self.repository.create_event(
+            title=clean_payload.get("title"),
+            event_date=event_date,
+            location=clean_payload.get("location"),
+            event_type=clean_payload.get("event_type"),
+            attendees=clean_payload.get("attendees", 0),
+            timezone=clean_payload.get("timezone", "UTC"),
+            status=clean_payload.get("status", "draft"),
+            capacity_limit=clean_payload.get("capacity_limit"),
+            recurrence_rule=clean_payload.get("recurrence_rule"),
+            default_locale=clean_payload.get("default_locale", "fr"),
+            fallback_locale=clean_payload.get("fallback_locale"),
+            organizer_email=clean_payload.get("organizer_email"),
+            settings=clean_payload.get("settings"),
+            series=series,
+            template=None,
+            categories=categories,
+            tags=tags,
+        )
+
+        for translation in translations:
+            self.repository.upsert_translation(
+                event,
+                locale=translation["locale"],
+                title=translation["title"],
+                description=translation.get("description"),
+                fallback=translation.get("fallback"),
+            )
+
+        try:
+            self._ensure_capacity_constraints(event)
+        except ValidationError:
+            self.session.rollback()
+            raise
+
         self.session.commit()
         return self._serialize_event(event)
 
@@ -97,27 +214,164 @@ class EventService:
         except LookupError as exc:
             raise EventNotFoundError(str(exc)) from exc
 
-        series_name = clean_payload.pop("series_name", None)
-        series_id = clean_payload.pop("series_id", None)
-        if series_name is not None or series_id is not None:
-            if series_id is not None:
-                if series_id == 0:
-                    self.repository.assign_series(event, None)
-                else:
-                    series = self.repository.get_series_by_id(series_id)
-                    if series is None:
-                        raise ValidationError({"series_id": ["Série introuvable."]})
-                    self.repository.assign_series(event, series)
-            elif series_name:
-                series = self.repository.get_or_create_series(series_name)
-                self.repository.assign_series(event, series)
+        series = self._resolve_series(clean_payload, current_event=event)
+        categories = self._resolve_categories(clean_payload)
+        tags = self._resolve_tags(clean_payload)
+        translations = clean_payload.pop("translations", None)
+        series_specified = clean_payload.pop("_series_specified", False)
+        categories_specified = clean_payload.pop("_categories_specified", False)
+        tags_specified = clean_payload.pop("_tags_specified", False)
 
-        if "event_date" in clean_payload:
-            clean_payload["event_date"] = clean_payload["event_date"]
+        updates = {}
+        for field in [
+            "title",
+            "location",
+            "event_type",
+            "attendees",
+            "event_date",
+            "timezone",
+            "status",
+            "capacity_limit",
+            "recurrence_rule",
+            "default_locale",
+            "fallback_locale",
+            "organizer_email",
+            "settings",
+        ]:
+            if field in clean_payload:
+                updates[field] = clean_payload[field]
 
-        updated_event = self.repository.update_event(event, clean_payload)
+        if updates:
+            event = self.repository.update_event(event, updates)
+
+        if series_specified:
+            self.repository.assign_series(event, series)
+
+        if categories_specified:
+            self.repository.assign_categories(event, categories)
+
+        if tags_specified:
+            self.repository.assign_tags(event, tags)
+
+        if translations is not None:
+            for translation in translations:
+                self.repository.upsert_translation(
+                    event,
+                    locale=translation["locale"],
+                    title=translation["title"],
+                    description=translation.get("description"),
+                    fallback=translation.get("fallback"),
+                )
+
+        try:
+            self._ensure_capacity_constraints(event)
+        except ValidationError:
+            self.session.rollback()
+            raise
+
         self.session.commit()
-        return self._serialize_event(updated_event)
+        return self._serialize_event(event)
+
+    def create_event_from_template(
+        self, template_id: int, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        try:
+            template = self.template_repository.get(template_id)
+        except LookupError as exc:
+            raise ValidationError({"template_id": [str(exc)]}) from exc
+
+        merged_payload = self._build_payload_from_template(template, payload)
+        clean_payload = self._validate_event_payload(merged_payload, require_title=True)
+
+        event_date = clean_payload.pop("event_date", date.today())
+        series = self._resolve_series(clean_payload)
+        categories = self._resolve_categories(clean_payload)
+        tags = self._resolve_tags(clean_payload)
+        translations = clean_payload.pop("translations", [])
+        clean_payload.pop("_series_specified", None)
+        clean_payload.pop("_categories_specified", None)
+        clean_payload.pop("_tags_specified", None)
+
+        event = self.repository.create_event(
+            title=clean_payload.get("title"),
+            event_date=event_date,
+            location=clean_payload.get("location"),
+            event_type=clean_payload.get("event_type", template.description),
+            attendees=clean_payload.get("attendees", 0),
+            timezone=clean_payload.get("timezone", template.default_timezone),
+            status=clean_payload.get("status", "draft"),
+            capacity_limit=clean_payload.get("capacity_limit", template.default_capacity_limit),
+            recurrence_rule=clean_payload.get("recurrence_rule"),
+            default_locale=clean_payload.get("default_locale", template.default_locale),
+            fallback_locale=clean_payload.get("fallback_locale", template.fallback_locale),
+            organizer_email=clean_payload.get("organizer_email"),
+            settings=clean_payload.get("settings"),
+            series=series,
+            template=template,
+            categories=categories,
+            tags=tags,
+        )
+
+        for translation in translations or self._default_template_translations(template):
+            self.repository.upsert_translation(
+                event,
+                locale=translation["locale"],
+                title=translation["title"],
+                description=translation.get("description"),
+                fallback=translation.get("fallback"),
+            )
+
+        try:
+            self._ensure_capacity_constraints(event)
+        except ValidationError:
+            self.session.rollback()
+            raise
+
+        self.session.commit()
+        return self._serialize_event(event)
+
+    def upsert_translation(
+        self, event_id: int, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        translation_payload = validate_translation_payload(payload, require_locale=True)
+        try:
+            event = self.repository.get_event(event_id)
+        except LookupError as exc:
+            raise EventNotFoundError(str(exc)) from exc
+
+        translation = self.repository.upsert_translation(
+            event,
+            locale=translation_payload["locale"],
+            title=translation_payload["title"],
+            description=translation_payload.get("description"),
+            fallback=translation_payload.get("fallback"),
+        )
+        self.session.commit()
+        return self._serialize_translation(translation, event)
+
+    def delete_translation(self, event_id: int, locale: str) -> None:
+        if not locale or not isinstance(locale, str):
+            raise ValidationError({"locale": ["Locale invalide."]})
+        try:
+            event = self.repository.get_event(event_id)
+        except LookupError as exc:
+            raise EventNotFoundError(str(exc)) from exc
+
+        try:
+            self.repository.remove_translation(event, locale)
+        except LookupError as exc:
+            raise ValidationError({"locale": [str(exc)]}) from exc
+
+        self.session.commit()
+
+    def submit_for_approval(self, event_id: int, actor: Optional[str], notes: Optional[str]) -> Dict[str, Any]:
+        return self._transition_status(event_id, "pending", actor, notes)
+
+    def approve_event(self, event_id: int, actor: Optional[str], notes: Optional[str]) -> Dict[str, Any]:
+        return self._transition_status(event_id, "approved", actor, notes)
+
+    def reject_event(self, event_id: int, actor: Optional[str], notes: Optional[str]) -> Dict[str, Any]:
+        return self._transition_status(event_id, "rejected", actor, notes)
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -162,10 +416,6 @@ class EventService:
             if provided_date is None:
                 if require_title:
                     clean["event_date"] = date.today()
-                else:
-                    errors.setdefault("date", []).append(
-                        "Doit être une chaîne au format YYYY-MM-DD."
-                    )
             elif not isinstance(provided_date, str) or not provided_date.strip():
                 errors.setdefault("date", []).append(
                     "Doit être une chaîne au format YYYY-MM-DD."
@@ -190,6 +440,88 @@ class EventService:
             clean["event_type"] = event_type.strip() if isinstance(event_type, str) else event_type
         elif require_title:
             clean.setdefault("event_type", "general")
+
+        if "timezone" in data or require_title:
+            timezone = data.get("timezone", "UTC")
+            if timezone is None:
+                timezone = "UTC"
+            if not isinstance(timezone, str) or not timezone.strip():
+                errors.setdefault("timezone", []).append("Fuseau horaire invalide.")
+            else:
+                try:
+                    ZoneInfo(timezone.strip())
+                    clean["timezone"] = timezone.strip()
+                except ZoneInfoNotFoundError:
+                    errors.setdefault("timezone", []).append("Fuseau horaire introuvable.")
+
+        if "status" in data or require_title:
+            status = data.get("status", "draft")
+            if status not in ALLOWED_STATUSES:
+                errors.setdefault("status", []).append("Statut inconnu.")
+            else:
+                clean["status"] = status
+
+        if "capacity_limit" in data:
+            capacity = data.get("capacity_limit")
+            if capacity is None:
+                clean["capacity_limit"] = None
+            elif isinstance(capacity, bool) or not isinstance(capacity, int) or capacity < 0:
+                errors.setdefault("capacity_limit", []).append(
+                    "Doit être un entier >= 0 ou null."
+                )
+            else:
+                clean["capacity_limit"] = capacity
+
+        if "capacity_limit" in clean and "attendees" in clean:
+            capacity = clean.get("capacity_limit")
+            attendees_value = clean.get("attendees", 0)
+            if capacity is not None and attendees_value is not None and capacity < attendees_value:
+                errors.setdefault("capacity_limit", []).append(
+                    "La capacité doit être supérieure ou égale au nombre de participants."
+                )
+
+        if "recurrence_rule" in data:
+            rule = data.get("recurrence_rule")
+            if rule is None or not isinstance(rule, str) or "FREQ" not in rule.upper():
+                errors.setdefault("recurrence_rule", []).append(
+                    "Règle de récurrence invalide (doit contenir FREQ)."
+                )
+            else:
+                clean["recurrence_rule"] = rule
+
+        if "default_locale" in data or require_title:
+            locale = data.get("default_locale", "fr")
+            if not isinstance(locale, str) or not is_valid_locale(locale):
+                errors.setdefault("default_locale", []).append("Locale invalide.")
+            else:
+                clean["default_locale"] = locale.replace("_", "-")
+
+        if "fallback_locale" in data:
+            fallback_locale = data.get("fallback_locale")
+            if fallback_locale is None:
+                clean["fallback_locale"] = None
+            elif not isinstance(fallback_locale, str) or not is_valid_locale(fallback_locale):
+                errors.setdefault("fallback_locale", []).append("Locale fallback invalide.")
+            else:
+                clean["fallback_locale"] = fallback_locale.replace("_", "-")
+
+        if "organizer_email" in data:
+            organizer_email = data.get("organizer_email")
+            if organizer_email is None:
+                clean["organizer_email"] = None
+            elif not isinstance(organizer_email, str) or not EMAIL_PATTERN.match(organizer_email):
+                errors.setdefault("organizer_email", []).append("Email invalide.")
+            else:
+                clean["organizer_email"] = organizer_email
+
+        if "settings" in data:
+            settings = data.get("settings")
+            if settings is None:
+                clean["settings"] = None
+            elif not isinstance(settings, dict):
+                errors.setdefault("settings", []).append("Doit être un objet JSON.")
+            else:
+                clean["settings"] = copy.deepcopy(settings)
 
         if "series" in data:
             series = data.get("series")
@@ -216,14 +548,42 @@ class EventService:
         if "series_id" in data:
             series_id = data.get("series_id")
             if series_id is None:
-                if not require_title:
-                    clean["series_id"] = 0
+                clean["series_id"] = None
             elif not isinstance(series_id, int) or series_id < 0:
                 errors.setdefault("series_id", []).append(
                     "Doit être un entier >= 0."
                 )
             else:
                 clean["series_id"] = series_id
+
+        if "category_ids" in data:
+            clean["category_ids"], cat_errors = self._validate_id_list(data["category_ids"], "category_ids")
+            if cat_errors:
+                errors.setdefault("category_ids", []).extend(cat_errors)
+
+        if "tag_ids" in data:
+            clean["tag_ids"], tag_errors = self._validate_id_list(data["tag_ids"], "tag_ids")
+            if tag_errors:
+                errors.setdefault("tag_ids", []).extend(tag_errors)
+
+        if "translations" in data:
+            translations = data.get("translations")
+            if translations is None:
+                clean["translations"] = []
+            elif not isinstance(translations, list):
+                errors.setdefault("translations", []).append("Doit être une liste de traductions.")
+            else:
+                parsed_translations = []
+                for idx, translation in enumerate(translations):
+                    try:
+                        parsed = validate_translation_payload(translation, require_locale=True)
+                    except ValidationError as exc:
+                        for key, messages in exc.errors.items():
+                            errors.setdefault(f"translations[{idx}].{key}", []).extend(messages)
+                    else:
+                        parsed_translations.append(parsed)
+                if parsed_translations:
+                    clean["translations"] = parsed_translations
 
         if errors:
             raise ValidationError(errors)
@@ -247,15 +607,211 @@ class EventService:
         stripped = value.strip()
         return stripped or None
 
+    def _validate_id_list(self, value: Any, field: str) -> Tuple[List[int], List[str]]:
+        if value is None:
+            return [], []
+        if not isinstance(value, list):
+            return [], ["Doit être une liste d'identifiants entiers."]
+        ids: List[int] = []
+        errors: List[str] = []
+        for item in value:
+            if not isinstance(item, int) or item < 0:
+                errors.append("Chaque identifiant doit être un entier >= 0.")
+            else:
+                ids.append(item)
+        return ids, errors
+
+    def _resolve_series(
+        self, payload: Dict[str, Any], current_event=None
+    ) -> Optional[EventSeries]:
+        series_specified = "series_id" in payload or "series_name" in payload
+        series_id = payload.pop("series_id", None) if "series_id" in payload else None
+        series_name = payload.pop("series_name", None) if "series_name" in payload else None
+
+        if series_id is not None:
+            if series_id == 0:
+                payload["_series_specified"] = True
+                return None
+            try:
+                series = self.series_repository.get(series_id)
+                payload["_series_specified"] = True
+                return series
+            except LookupError as exc:
+                raise ValidationError({"series_id": [str(exc)]}) from exc
+
+        if series_name:
+            existing = self.series_repository.get_by_name(series_name)
+            if existing:
+                payload["_series_specified"] = True
+                return existing
+            payload["_series_specified"] = True
+            return self.series_repository.create(name=series_name, description=None)
+
+        if series_specified:
+            payload["_series_specified"] = True
+            return None
+
+        if current_event is not None:
+            return current_event.series
+        return None
+
+    def _resolve_categories(self, payload: Dict[str, Any]) -> Optional[List[EventCategory]]:
+        if "category_ids" not in payload:
+            return None
+        category_ids = payload.pop("category_ids", [])
+        payload["_categories_specified"] = True
+        if not category_ids:
+            return []
+        categories = []
+        missing = []
+        for category_id in category_ids:
+            category = self.session.get(EventCategory, category_id)
+            if category is None:
+                missing.append(str(category_id))
+            else:
+                categories.append(category)
+        if missing:
+            raise ValidationError({"category_ids": [f"Catégories introuvables: {', '.join(missing)}"]})
+        return categories
+
+    def _resolve_tags(self, payload: Dict[str, Any]) -> Optional[List[EventTag]]:
+        if "tag_ids" not in payload:
+            return None
+        tag_ids = payload.pop("tag_ids", [])
+        payload["_tags_specified"] = True
+        if not tag_ids:
+            return []
+        tags = []
+        missing = []
+        for tag_id in tag_ids:
+            tag = self.session.get(EventTag, tag_id)
+            if tag is None:
+                missing.append(str(tag_id))
+            else:
+                tags.append(tag)
+        if missing:
+            raise ValidationError({"tag_ids": [f"Tags introuvables: {', '.join(missing)}"]})
+        return tags
+
+    def _ensure_capacity_constraints(self, event) -> None:
+        if event.capacity_limit is not None and event.capacity_limit < event.attendees:
+            raise ValidationError(
+                {"capacity_limit": ["La capacité doit être supérieure ou égale au nombre de participants."]}
+            )
+
+    def _build_payload_from_template(self, template, payload: Dict[str, Any]) -> Dict[str, Any]:
+        merged = {
+            "title": payload.get("title") or template.name,
+            "date": payload.get("date"),
+            "location": payload.get("location"),
+            "type": payload.get("type") or template.description,
+            "attendees": payload.get("attendees", 0),
+            "timezone": payload.get("timezone") or template.default_timezone,
+            "status": payload.get("status", "draft"),
+            "capacity_limit": payload.get("capacity_limit", template.default_capacity_limit),
+            "recurrence_rule": payload.get("recurrence_rule"),
+            "default_locale": payload.get("default_locale", template.default_locale),
+            "fallback_locale": payload.get("fallback_locale", template.fallback_locale),
+            "organizer_email": payload.get("organizer_email"),
+            "settings": self._merge_settings(template.default_metadata, payload.get("settings")),
+            "series_id": payload.get("series_id"),
+            "series_name": payload.get("series_name"),
+            "category_ids": payload.get("category_ids"),
+            "tag_ids": payload.get("tag_ids"),
+            "translations": payload.get("translations"),
+        }
+        return merged
+
+    @staticmethod
+    def _merge_settings(template_settings: Optional[dict], event_settings: Optional[dict]) -> Optional[dict]:
+        if template_settings is None and event_settings is None:
+            return None
+        merged = {}
+        if isinstance(template_settings, dict):
+            merged.update(template_settings)
+        if isinstance(event_settings, dict):
+            merged.update(event_settings)
+        return merged
+
+    def _default_template_translations(self, template) -> Iterable[Dict[str, Any]]:
+        for translation in template.translations:
+            yield {
+                "locale": translation.locale,
+                "title": translation.title,
+                "description": translation.description,
+                "fallback": translation.locale == template.fallback_locale,
+            }
+
+    def _transition_status(
+        self, event_id: int, new_status: str, actor: Optional[str], notes: Optional[str]
+    ) -> Dict[str, Any]:
+        try:
+            event = self.repository.get_event(event_id)
+        except LookupError as exc:
+            raise EventNotFoundError(str(exc)) from exc
+
+        current_status = event.status
+        allowed_transitions = {
+            "draft": {"pending"},
+            "pending": {"approved", "rejected"},
+            "rejected": {"pending"},
+            "approved": set(),
+        }
+        if new_status not in allowed_transitions.get(current_status, set()):
+            raise ApprovalWorkflowError(
+                f"Transition de {current_status} vers {new_status} non autorisée."
+            )
+
+        log = self.repository.log_status_change(
+            event,
+            previous_status=current_status,
+            new_status=new_status,
+            actor=actor,
+            notes=notes,
+        )
+
+        if event.organizer_email:
+            message = f"Votre événement '{event.title}' est désormais {new_status}."
+            self.repository.create_notification(
+                event,
+                recipient=event.organizer_email,
+                message=message,
+            )
+
+        self.session.commit()
+        return {
+            "event": self._serialize_event(event),
+            "log": {
+                "id": log.id,
+                "previous_status": log.previous_status,
+                "new_status": log.new_status,
+                "actor": log.actor,
+                "notes": log.notes,
+                "created_at": log.created_at.isoformat(),
+            },
+        }
+
     def _serialize_event(self, event) -> Dict[str, Any]:
         return {
             "id": event.id,
             "title": event.title,
-            "date": event.event_date.isoformat(),
+            "date": event.event_date.isoformat() if event.event_date else None,
             "location": event.location,
             "type": event.event_type,
             "attendees": event.attendees,
+            "timezone": event.timezone,
+            "status": event.status,
+            "capacity_limit": event.capacity_limit,
+            "recurrence_rule": event.recurrence_rule,
+            "default_locale": event.default_locale,
+            "fallback_locale": event.fallback_locale,
+            "organizer_email": event.organizer_email,
+            "settings": copy.deepcopy(event.settings) if event.settings else None,
             "series": self._serialize_series(event.series),
+            "template_id": event.template_id,
+            "categories": [self._serialize_category(category) for category in event.categories],
+            "tags": [self._serialize_tag(tag) for tag in event.tags],
+            "translations": [self._serialize_translation(t, event) for t in event.translations],
             "created_at": self._serialize_datetime(event.created_at),
             "updated_at": self._serialize_datetime(event.updated_at),
         }
@@ -264,8 +820,394 @@ class EventService:
     def _serialize_series(series) -> Optional[Dict[str, Any]]:
         if series is None:
             return None
-        return {"id": series.id, "name": series.name}
+        return {"id": series.id, "name": series.name, "description": series.description}
+
+    @staticmethod
+    def _serialize_category(category) -> Dict[str, Any]:
+        return {"id": category.id, "name": category.name, "description": category.description}
+
+    @staticmethod
+    def _serialize_tag(tag) -> Dict[str, Any]:
+        return {"id": tag.id, "name": tag.name}
+
+    @staticmethod
+    def _serialize_translation(translation, event=None) -> Dict[str, Any]:
+        return {
+            "locale": translation.locale,
+            "title": translation.title,
+            "description": translation.description,
+            "fallback": bool(event and event.fallback_locale == translation.locale),
+        }
 
     @staticmethod
     def _serialize_datetime(value: Optional[datetime]) -> Optional[str]:
         return value.isoformat() if value else None
+
+
+class CatalogBaseService:
+    """Base class for catalog management services."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def _ensure_name(self, payload: Dict[str, Any], field: str = "name") -> str:
+        name = payload.get(field)
+        if not isinstance(name, str) or not name.strip():
+            raise ValidationError({field: ["Nom requis."]})
+        return name.strip()
+
+
+class CategoryService(CatalogBaseService):
+    """Service for managing event categories."""
+
+    def __init__(self, session: Session) -> None:
+        super().__init__(session)
+        self.repository = CategoryRepository(session)
+
+    def list_categories(self) -> List[Dict[str, Any]]:
+        categories = self.repository.list()
+        return [self._serialize(category) for category in categories]
+
+    def get_category(self, category_id: int) -> Dict[str, Any]:
+        try:
+            category = self.repository.get(category_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+        return self._serialize(category)
+
+    def create_category(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        name = self._ensure_name(payload)
+        description = payload.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValidationError({"description": ["Description invalide."]})
+        category = self.repository.create(name=name, description=description)
+        self.session.commit()
+        return self._serialize(category)
+
+    def update_category(self, category_id: int, payload: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            category = self.repository.get(category_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+
+        name = payload.get("name")
+        if name is not None and (not isinstance(name, str) or not name.strip()):
+            raise ValidationError({"name": ["Nom invalide."]})
+        description = payload.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValidationError({"description": ["Description invalide."]})
+
+        category = self.repository.update(
+            category,
+            name=name.strip() if isinstance(name, str) and name.strip() else None,
+            description=description,
+        )
+        self.session.commit()
+        return self._serialize(category)
+
+    def delete_category(self, category_id: int) -> None:
+        try:
+            category = self.repository.get(category_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+        self.repository.delete(category)
+        self.session.commit()
+
+    @staticmethod
+    def _serialize(category) -> Dict[str, Any]:
+        return {"id": category.id, "name": category.name, "description": category.description}
+
+
+class TagService(CatalogBaseService):
+    """Service for managing event tags."""
+
+    def __init__(self, session: Session) -> None:
+        super().__init__(session)
+        self.repository = TagRepository(session)
+
+    def list_tags(self) -> List[Dict[str, Any]]:
+        tags = self.repository.list()
+        return [self._serialize(tag) for tag in tags]
+
+    def get_tag(self, tag_id: int) -> Dict[str, Any]:
+        try:
+            tag = self.repository.get(tag_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+        return self._serialize(tag)
+
+    def create_tag(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        name = self._ensure_name(payload)
+        tag = self.repository.create(name=name)
+        self.session.commit()
+        return self._serialize(tag)
+
+    def update_tag(self, tag_id: int, payload: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            tag = self.repository.get(tag_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+
+        name = payload.get("name")
+        if name is not None and (not isinstance(name, str) or not name.strip()):
+            raise ValidationError({"name": ["Nom invalide."]})
+
+        tag = self.repository.update(tag, name=name.strip() if isinstance(name, str) and name.strip() else None)
+        self.session.commit()
+        return self._serialize(tag)
+
+    def delete_tag(self, tag_id: int) -> None:
+        try:
+            tag = self.repository.get(tag_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+        self.repository.delete(tag)
+        self.session.commit()
+
+    @staticmethod
+    def _serialize(tag) -> Dict[str, Any]:
+        return {"id": tag.id, "name": tag.name}
+
+
+class SeriesService(CatalogBaseService):
+    """Service for managing event series."""
+
+    def __init__(self, session: Session) -> None:
+        super().__init__(session)
+        self.repository = SeriesRepository(session)
+
+    def list_series(self) -> List[Dict[str, Any]]:
+        series_list = self.repository.list()
+        return [self._serialize(series) for series in series_list]
+
+    def get_series(self, series_id: int) -> Dict[str, Any]:
+        try:
+            series = self.repository.get(series_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+        return self._serialize(series)
+
+    def create_series(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        name = self._ensure_name(payload)
+        description = payload.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValidationError({"description": ["Description invalide."]})
+        series = self.repository.create(name=name, description=description)
+        self.session.commit()
+        return self._serialize(series)
+
+    def update_series(self, series_id: int, payload: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            series = self.repository.get(series_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+
+        name = payload.get("name")
+        if name is not None and (not isinstance(name, str) or not name.strip()):
+            raise ValidationError({"name": ["Nom invalide."]})
+        description = payload.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValidationError({"description": ["Description invalide."]})
+
+        series = self.repository.update(
+            series,
+            name=name.strip() if isinstance(name, str) and name.strip() else None,
+            description=description,
+        )
+        self.session.commit()
+        return self._serialize(series)
+
+    def delete_series(self, series_id: int) -> None:
+        try:
+            series = self.repository.get(series_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+        self.repository.delete(series)
+        self.session.commit()
+
+    @staticmethod
+    def _serialize(series) -> Dict[str, Any]:
+        return {
+            "id": series.id,
+            "name": series.name,
+            "description": series.description,
+        }
+
+
+class TemplateService(CatalogBaseService):
+    """Service for managing event templates."""
+
+    def __init__(self, session: Session) -> None:
+        super().__init__(session)
+        self.repository = TemplateRepository(session)
+
+    def list_templates(self) -> List[Dict[str, Any]]:
+        templates = self.repository.list()
+        return [self._serialize(template) for template in templates]
+
+    def get_template(self, template_id: int) -> Dict[str, Any]:
+        try:
+            template = self.repository.get(template_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+        return self._serialize(template)
+
+    def create_template(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        name = self._ensure_name(payload)
+        description = payload.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValidationError({"description": ["Description invalide."]})
+
+        default_duration = self._validate_optional_int(payload.get("default_duration_minutes"), "default_duration_minutes")
+        default_capacity = self._validate_optional_int(payload.get("default_capacity_limit"), "default_capacity_limit")
+        timezone = payload.get("default_timezone", "UTC")
+        if not isinstance(timezone, str) or not timezone.strip():
+            raise ValidationError({"default_timezone": ["Fuseau horaire invalide."]})
+        try:
+            ZoneInfo(timezone.strip())
+        except ZoneInfoNotFoundError as exc:
+            raise ValidationError({"default_timezone": ["Fuseau horaire introuvable."]}) from exc
+
+        default_locale = payload.get("default_locale", "fr")
+        if not isinstance(default_locale, str) or not is_valid_locale(default_locale):
+            raise ValidationError({"default_locale": ["Locale invalide."]})
+
+        fallback_locale = payload.get("fallback_locale")
+        if fallback_locale is not None and (not isinstance(fallback_locale, str) or not is_valid_locale(fallback_locale)):
+            raise ValidationError({"fallback_locale": ["Locale invalide."]})
+
+        default_metadata = payload.get("default_metadata")
+        if default_metadata is not None and not isinstance(default_metadata, dict):
+            raise ValidationError({"default_metadata": ["Doit être un objet JSON."]})
+
+        template = self.repository.create(
+            name=name,
+            description=description,
+            default_duration_minutes=default_duration,
+            default_timezone=timezone.strip(),
+            default_locale=default_locale.replace("_", "-"),
+            fallback_locale=fallback_locale.replace("_", "-") if isinstance(fallback_locale, str) else None,
+            default_capacity_limit=default_capacity,
+            default_metadata=copy.deepcopy(default_metadata) if default_metadata else None,
+        )
+        self.session.commit()
+        return self._serialize(template)
+
+    def update_template(self, template_id: int, payload: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            template = self.repository.get(template_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+
+        description = payload.get("description")
+        if description is not None and not isinstance(description, str):
+            raise ValidationError({"description": ["Description invalide."]})
+
+        default_duration = self._validate_optional_int(payload.get("default_duration_minutes"), "default_duration_minutes")
+        default_capacity = self._validate_optional_int(payload.get("default_capacity_limit"), "default_capacity_limit")
+
+        timezone = payload.get("default_timezone")
+        if timezone is not None:
+            if not isinstance(timezone, str) or not timezone.strip():
+                raise ValidationError({"default_timezone": ["Fuseau horaire invalide."]})
+            try:
+                ZoneInfo(timezone.strip())
+            except ZoneInfoNotFoundError as exc:
+                raise ValidationError({"default_timezone": ["Fuseau horaire introuvable."]}) from exc
+
+        default_locale = payload.get("default_locale")
+        if default_locale is not None and (not isinstance(default_locale, str) or not is_valid_locale(default_locale)):
+            raise ValidationError({"default_locale": ["Locale invalide."]})
+
+        fallback_locale = payload.get("fallback_locale")
+        if fallback_locale is not None and fallback_locale != "" and (not isinstance(fallback_locale, str) or not is_valid_locale(fallback_locale)):
+            raise ValidationError({"fallback_locale": ["Locale invalide."]})
+
+        default_metadata = payload.get("default_metadata")
+        if default_metadata is not None and default_metadata != {} and not isinstance(default_metadata, dict):
+            raise ValidationError({"default_metadata": ["Doit être un objet JSON."]})
+
+        template = self.repository.update(
+            template,
+            description=description,
+            default_duration_minutes=default_duration,
+            default_timezone=timezone.strip() if isinstance(timezone, str) else None,
+            default_locale=default_locale.replace("_", "-") if isinstance(default_locale, str) else None,
+            fallback_locale=fallback_locale.replace("_", "-") if isinstance(fallback_locale, str) else fallback_locale,
+            default_capacity_limit=default_capacity,
+            default_metadata=copy.deepcopy(default_metadata) if isinstance(default_metadata, dict) else None,
+        )
+        self.session.commit()
+        return self._serialize(template)
+
+    def delete_template(self, template_id: int) -> None:
+        try:
+            template = self.repository.get(template_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+        self.repository.delete(template)
+        self.session.commit()
+
+    def upsert_translation(self, template_id: int, payload: Dict[str, Any]) -> Dict[str, Any]:
+        try:
+            template = self.repository.get(template_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+
+        translation_payload = {
+            "locale": payload.get("locale"),
+            "title": payload.get("title"),
+            "description": payload.get("description"),
+        }
+        parsed = validate_translation_payload(translation_payload, require_locale=True)
+        translation = self.repository.upsert_translation(
+            template,
+            locale=parsed["locale"],
+            title=parsed["title"],
+            description=parsed.get("description"),
+        )
+        self.session.commit()
+        return self._serialize_translation(translation)
+
+    def delete_translation(self, template_id: int, locale: str) -> None:
+        if not isinstance(locale, str) or not locale:
+            raise ValidationError({"locale": ["Locale invalide."]})
+        try:
+            template = self.repository.get(template_id)
+        except LookupError as exc:
+            raise ValidationError({"id": [str(exc)]}) from exc
+        try:
+            self.repository.remove_translation(template, locale)
+        except LookupError as exc:
+            raise ValidationError({"locale": [str(exc)]}) from exc
+        self.session.commit()
+
+    def _serialize(self, template) -> Dict[str, Any]:
+        return {
+            "id": template.id,
+            "name": template.name,
+            "description": template.description,
+            "default_duration_minutes": template.default_duration_minutes,
+            "default_timezone": template.default_timezone,
+            "default_locale": template.default_locale,
+            "fallback_locale": template.fallback_locale,
+            "default_capacity_limit": template.default_capacity_limit,
+            "default_metadata": copy.deepcopy(template.default_metadata) if template.default_metadata else None,
+            "translations": [self._serialize_translation(t) for t in template.translations],
+        }
+
+    @staticmethod
+    def _serialize_translation(translation) -> Dict[str, Any]:
+        return {
+            "locale": translation.locale,
+            "title": translation.title,
+            "description": translation.description,
+        }
+
+    def _validate_optional_int(self, value: Any, field: str) -> Optional[int]:
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValidationError({field: ["Doit être un entier >= 0 ou null."]})
+        return value
+

--- a/tests/test_extended.py
+++ b/tests/test_extended.py
@@ -1,0 +1,150 @@
+import pytest
+
+
+def test_category_crud(client):
+    create_resp = client.post(
+        "/event-categories",
+        json={"name": "Workshops", "description": "Hands-on"},
+    )
+    assert create_resp.status_code == 201
+    category_id = create_resp.json["category"]["id"]
+
+    list_resp = client.get("/event-categories")
+    assert list_resp.status_code == 200
+    assert any(cat["id"] == category_id for cat in list_resp.json["categories"])
+
+    get_resp = client.get(f"/event-categories/{category_id}")
+    assert get_resp.status_code == 200
+    assert get_resp.json["category"]["name"] == "Workshops"
+
+    update_resp = client.patch(
+        f"/event-categories/{category_id}",
+        json={"description": "Workshops and labs"},
+    )
+    assert update_resp.status_code == 200
+    assert update_resp.json["category"]["description"] == "Workshops and labs"
+
+    delete_resp = client.delete(f"/event-categories/{category_id}")
+    assert delete_resp.status_code == 204
+
+    missing_resp = client.get(f"/event-categories/{category_id}")
+    assert missing_resp.status_code == 404
+
+
+def test_tag_crud(client):
+    create_resp = client.post("/event-tags", json={"name": "hybrid"})
+    assert create_resp.status_code == 201
+    tag_id = create_resp.json["tag"]["id"]
+
+    get_resp = client.get(f"/event-tags/{tag_id}")
+    assert get_resp.status_code == 200
+
+    update_resp = client.put(f"/event-tags/{tag_id}", json={"name": "remote"})
+    assert update_resp.status_code == 200
+    assert update_resp.json["tag"]["name"] == "remote"
+
+    delete_resp = client.delete(f"/event-tags/{tag_id}")
+    assert delete_resp.status_code == 204
+
+
+def test_template_instantiation_and_translations(client):
+    template_payload = {
+        "name": "Meetup template",
+        "description": "Default meetup",
+        "default_duration_minutes": 90,
+        "default_timezone": "Europe/Paris",
+        "default_locale": "fr-FR",
+        "fallback_locale": "en-US",
+        "default_capacity_limit": 200,
+        "default_metadata": {"visibility": "public"},
+    }
+    template_resp = client.post("/event-templates", json=template_payload)
+    assert template_resp.status_code == 201
+    template_id = template_resp.json["template"]["id"]
+
+    translation_resp = client.post(
+        f"/event-templates/{template_id}/translations",
+        json={"locale": "en-US", "title": "Meetup", "description": "Default"},
+    )
+    assert translation_resp.status_code == 201
+
+    instantiate_payload = {
+        "template_id": template_id,
+        "overrides": {
+            "title": "Paris Developers", "date": "2026-01-10", "attendees": 25
+        },
+    }
+    create_event = client.post("/events/from-template", json=instantiate_payload)
+    assert create_event.status_code == 201
+    event = create_event.json["event"]
+    assert event["timezone"] == "Europe/Paris"
+    assert event["default_locale"] == "fr-FR"
+    assert any(t["locale"] == "en-US" for t in event["translations"])
+    assert event["settings"]["visibility"] == "public"
+
+
+def test_event_translation_workflow(client):
+    create_resp = client.post(
+        "/events",
+        json={"title": "Localised", "date": "2026-05-05"},
+    )
+    event_id = create_resp.json["event_id"]
+
+    add_resp = client.post(
+        f"/events/{event_id}/translations",
+        json={"locale": "en-GB", "title": "Localized", "fallback": True},
+    )
+    assert add_resp.status_code == 201
+    assert add_resp.json["translation"]["fallback"] is True
+
+    update_resp = client.put(
+        f"/events/{event_id}/translations/en-GB",
+        json={"title": "Localized event"},
+    )
+    assert update_resp.status_code == 200
+    assert update_resp.json["translation"]["title"] == "Localized event"
+
+    get_resp = client.get(f"/events/{event_id}")
+    translations = get_resp.json["event"]["translations"]
+    assert any(t["locale"] == "en-GB" and t["fallback"] for t in translations)
+
+    delete_resp = client.delete(f"/events/{event_id}/translations/en-GB")
+    assert delete_resp.status_code == 204
+
+
+def test_approval_workflow(client):
+    create_resp = client.post(
+        "/events",
+        json={"title": "Approval", "organizer_email": "orga@example.com"},
+    )
+    event_id = create_resp.json["event_id"]
+
+    submit = client.post(
+        f"/events/{event_id}/submit",
+        json={"actor": "alice", "notes": "Ready"},
+    )
+    assert submit.status_code == 200
+    assert submit.json["event"]["status"] == "pending"
+
+    approve = client.post(
+        f"/events/{event_id}/approve",
+        json={"actor": "bob", "notes": "Looks good"},
+    )
+    assert approve.status_code == 200
+    assert approve.json["event"]["status"] == "approved"
+
+    invalid = client.post(f"/events/{event_id}/approve")
+    assert invalid.status_code == 409
+
+
+@pytest.mark.parametrize(
+    "payload, field",
+    [
+        ({"title": "Bad TZ", "timezone": "Mars/Crater"}, "timezone"),
+        ({"title": "Bad recurrence", "recurrence_rule": "DAILY"}, "recurrence_rule"),
+    ],
+)
+def test_event_validation_errors(client, payload, field):
+    resp = client.post("/events", json=payload)
+    assert resp.status_code == 422
+    assert field in resp.json["error"]["details"]


### PR DESCRIPTION
## Summary
- extend SQLAlchemy models with categories, tags, multilingual metadata, approval logging, and notifications
- overhaul service layer to support catalog management, template instantiation, translations, and approval transitions while exposing new blueprints
- add repositories, Flask routes, and tests that cover taxonomy CRUD, template usage, translation lifecycle, and approval workflow

## Testing
- `pytest` *(fails: SQLAlchemy wheel cannot be downloaded in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d999b661188332a2337420698d7909