### PR TITLE
Add search, recommendations, and calendar features

### DIFF
--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -8,12 +8,16 @@ from .event_series import series_bp
 from .event_tags import tags_bp
 from .event_templates import templates_bp
 from .events import events_bp
+from .recommendations import recommendations_bp
+from .search import search_bp
 
 __all__ = ["register_blueprints"]
 
 
 def register_blueprints(app: Flask) -> None:
     app.register_blueprint(events_bp)
+    app.register_blueprint(search_bp)
+    app.register_blueprint(recommendations_bp)
     app.register_blueprint(categories_bp)
     app.register_blueprint(tags_bp)
     app.register_blueprint(series_bp)

--- a/src/routes/dependencies.py
+++ b/src/routes/dependencies.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Callable, Dict, Type, TypeVar
 
-from flask import g
+from flask import current_app, g
 
 from src.database import get_session
 from src.services.events import (
@@ -13,6 +13,8 @@ from src.services.events import (
     TagService,
     TemplateService,
 )
+from src.services.recommendations import RecommendationService
+from src.services.search import EventSearchService
 
 T = TypeVar("T")
 
@@ -23,6 +25,8 @@ SERVICE_FACTORIES: Dict[str, Callable[[Any], Any]] = {
     "series_service": SeriesService,
     "template_service": TemplateService,
 }
+
+EXTRA_SERVICE_KEYS = {"search_service", "recommendation_service"}
 
 
 def get_db_session():
@@ -51,6 +55,33 @@ def get_template_service() -> TemplateService:
     return _get_service("template_service", TemplateService)
 
 
+def get_search_service() -> EventSearchService:
+    if "search_service" not in g:
+        client = _get_search_client()
+        index_name = current_app.config.get("EVENTS_INDEX", "events")
+        event_service = get_event_service()
+        event_provider = lambda: event_service.list_events()
+        g["search_service"] = EventSearchService(
+            client,
+            index_name=index_name,
+            event_provider=event_provider,
+        )
+    return g["search_service"]
+
+
+def get_recommendation_service() -> RecommendationService:
+    if "recommendation_service" not in g:
+        event_service = get_event_service()
+        search_service = get_search_service()
+        user_client = _get_user_profile_client()
+        g["recommendation_service"] = RecommendationService(
+            event_service,
+            user_client,
+            search_service=search_service,
+        )
+    return g["recommendation_service"]
+
+
 def _get_service(key: str, factory: Type[T]) -> T:
     if key not in g:
         session = get_db_session()
@@ -62,9 +93,38 @@ def cleanup_services(exception):
     session = g.pop("db_session", None)
     for key in list(SERVICE_FACTORIES.keys()):
         g.pop(key, None)
+    for key in EXTRA_SERVICE_KEYS:
+        g.pop(key, None)
     if session is not None:
         try:
             if exception is not None:
                 session.rollback()
         finally:
             session.close()
+
+
+def _get_search_client():
+    factory = current_app.config.get("SEARCH_CLIENT_FACTORY")
+    if callable(factory):
+        return factory()
+    return current_app.config.get("SEARCH_CLIENT")
+
+
+def _get_user_profile_client():
+    client = current_app.config.get("USER_PROFILE_CLIENT")
+    if callable(client):
+        client = client()
+    if client is None:
+        client = _FallbackUserClient()
+    return client
+
+
+class _FallbackUserClient:
+    def get_user_profile(self, user_id: str) -> Dict[str, Any]:
+        return {
+            "user_id": user_id,
+            "preferred_categories": [],
+            "preferred_tags": [],
+            "preferred_languages": [],
+            "bookmarked_events": [],
+        }

--- a/src/routes/recommendations.py
+++ b/src/routes/recommendations.py
@@ -1,0 +1,21 @@
+"""Routes exposing personalised recommendations."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from src.routes.dependencies import get_recommendation_service
+from src.routes.utils import error_response
+
+recommendations_bp = Blueprint("recommendations", __name__)
+
+
+@recommendations_bp.get("/users/<user_id>/recommendations")
+def get_recommendations(user_id: str):
+    service = get_recommendation_service()
+    try:
+        limit = int(request.args.get("limit", 10))
+    except ValueError:
+        return error_response(422, "Paramètre limit invalide.")
+
+    recommendations = service.get_recommendations(user_id, limit=max(1, min(limit, 50)))
+    return jsonify({"user_id": user_id, "recommendations": recommendations})

--- a/src/routes/search.py
+++ b/src/routes/search.py
@@ -1,0 +1,72 @@
+"""Routes exposing the event search API."""
+from __future__ import annotations
+
+from flask import Blueprint, jsonify, request
+
+from src.routes.dependencies import get_search_service
+from src.routes.utils import error_response
+from src.services.search import SearchError
+
+search_bp = Blueprint("search", __name__)
+
+
+@search_bp.get("/search/events")
+def search_events():
+    service = get_search_service()
+
+    try:
+        page = int(request.args.get("page", 1))
+        size = int(request.args.get("size", 20))
+    except ValueError:
+        return error_response(422, "Paramètres de pagination invalides.")
+
+    lat, lon, radius = _parse_geo_params()
+    include_suggestions = request.args.get("suggest", "true").lower() != "false"
+
+    categories = _parse_list_param("category", "categories")
+    tags = _parse_list_param("tag", "tags")
+    languages = _parse_list_param("language", "languages")
+
+    try:
+        results = service.search_events(
+            text=request.args.get("q"),
+            categories=categories,
+            tags=tags,
+            languages=languages,
+            start_date=request.args.get("start"),
+            end_date=request.args.get("end"),
+            lat=lat,
+            lon=lon,
+            radius_km=radius,
+            page=page,
+            size=size,
+            sort=request.args.get("sort"),
+            include_suggestions=include_suggestions,
+        )
+    except SearchError as exc:
+        return error_response(503, str(exc))
+
+    return jsonify(results)
+
+
+def _parse_list_param(*keys):
+    values = []
+    for key in keys:
+        raw_values = request.args.getlist(key)
+        for value in raw_values:
+            if value:
+                values.extend(part.strip() for part in value.split(",") if part.strip())
+    return values
+
+
+def _parse_geo_params():
+    lat = request.args.get("lat")
+    lon = request.args.get("lon")
+    radius = request.args.get("radius") or request.args.get("radius_km")
+    try:
+        lat_value = float(lat) if lat is not None else None
+        lon_value = float(lon) if lon is not None else None
+        radius_value = float(radius) if radius is not None else None
+    except ValueError:
+        return None, None, None
+    return lat_value, lon_value, radius_value

--- a/src/search/indexer.py
+++ b/src/search/indexer.py
@@ -1,0 +1,189 @@
+"""Elasticsearch indexing helpers for event documents.
+
+This module centralises the transformation of the rich event payloads
+returned by :class:`src.services.events.EventService` into documents ready to
+be indexed in Elasticsearch.  It focuses on exposing geo capabilities,
+taxonomies (categories, tags) and localisation (translations/languages).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+__all__ = ["EventIndexer", "EventDocument"]
+
+
+@dataclass
+class EventDocument:
+    """Representation of an event ready for Elasticsearch indexing."""
+
+    id: int
+    title: str
+    description: Optional[str]
+    event_date: Optional[str]
+    timezone: Optional[str]
+    location: Optional[str]
+    coordinates: Optional[Dict[str, float]]
+    categories: List[str] = field(default_factory=list)
+    category_ids: List[int] = field(default_factory=list)
+    tags: List[str] = field(default_factory=list)
+    tag_ids: List[int] = field(default_factory=list)
+    languages: List[str] = field(default_factory=list)
+    default_locale: Optional[str] = None
+    fallback_locale: Optional[str] = None
+    status: Optional[str] = None
+    attendees: Optional[int] = None
+    series: Optional[str] = None
+    share_url: Optional[str] = None
+
+    def asdict(self) -> Dict[str, Any]:
+        payload = {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "event_date": self.event_date,
+            "timezone": self.timezone,
+            "location": self.location,
+            "coordinates": self.coordinates,
+            "categories": self.categories,
+            "category_ids": self.category_ids,
+            "tags": self.tags,
+            "tag_ids": self.tag_ids,
+            "languages": self.languages,
+            "default_locale": self.default_locale,
+            "fallback_locale": self.fallback_locale,
+            "status": self.status,
+            "attendees": self.attendees,
+            "series": self.series,
+            "share_url": self.share_url,
+            "indexed_at": datetime.utcnow().isoformat(),
+        }
+        return {key: value for key, value in payload.items() if value is not None}
+
+
+class EventIndexer:
+    """Helper wrapping Elasticsearch indexing operations for events."""
+
+    def __init__(self, client: Any, index_name: str = "events") -> None:
+        self.client = client
+        self.index_name = index_name
+
+    def build_document(self, event: Mapping[str, Any]) -> EventDocument:
+        """Convert an event payload into an :class:`EventDocument`."""
+
+        coordinates = self._extract_coordinates(event)
+        categories, category_ids = self._extract_taxonomy(event.get("categories"))
+        tags, tag_ids = self._extract_taxonomy(event.get("tags"))
+        languages = self._extract_languages(event)
+        series_name = None
+        series = event.get("series")
+        if isinstance(series, Mapping):
+            series_name = series.get("name")
+
+        share_url = None
+        share = event.get("share") if isinstance(event.get("share"), Mapping) else None
+        if share:
+            share_url = share.get("url")
+
+        return EventDocument(
+            id=int(event.get("id")),
+            title=str(event.get("title", "")),
+            description=event.get("description"),
+            event_date=event.get("date") or event.get("event_date"),
+            timezone=event.get("timezone"),
+            location=event.get("location"),
+            coordinates=coordinates,
+            categories=categories,
+            category_ids=category_ids,
+            tags=tags,
+            tag_ids=tag_ids,
+            languages=languages,
+            default_locale=event.get("default_locale"),
+            fallback_locale=event.get("fallback_locale"),
+            status=event.get("status"),
+            attendees=event.get("attendees"),
+            series=series_name,
+            share_url=share_url,
+        )
+
+    def index_event(self, event: Mapping[str, Any], *, refresh: bool = False) -> Dict[str, Any]:
+        document = self.build_document(event)
+        kwargs = {"index": self.index_name, "id": document.id, "document": document.asdict()}
+        if refresh:
+            kwargs["refresh"] = "wait_for" if refresh is True else refresh
+        return self.client.index(**kwargs)
+
+    def bulk_index_events(
+        self, events: Iterable[Mapping[str, Any]], *, refresh: bool = False
+    ) -> Dict[str, Any]:
+        operations: List[Dict[str, Any]] = []
+        for event in events:
+            document = self.build_document(event)
+            operations.append({"index": {"_index": self.index_name, "_id": document.id}})
+            operations.append(document.asdict())
+        kwargs: Dict[str, Any] = {"operations": operations}
+        if refresh:
+            kwargs["refresh"] = "wait_for" if refresh is True else refresh
+        return self.client.bulk(**kwargs)
+
+    def delete_event(self, event_id: int, *, refresh: bool = False) -> Dict[str, Any]:
+        kwargs = {"index": self.index_name, "id": int(event_id)}
+        if refresh:
+            kwargs["refresh"] = "wait_for" if refresh is True else refresh
+        return self.client.delete(**kwargs)
+
+    @staticmethod
+    def _extract_coordinates(event: Mapping[str, Any]) -> Optional[Dict[str, float]]:
+        settings = event.get("settings")
+        lat = event.get("latitude")
+        lon = event.get("longitude")
+
+        if not isinstance(lat, (int, float)) or not isinstance(lon, (int, float)):
+            if isinstance(settings, Mapping):
+                coordinates = settings.get("coordinates") or settings.get("geo")
+                if isinstance(coordinates, Mapping):
+                    lat = coordinates.get("lat")
+                    lon = coordinates.get("lon")
+                else:
+                    location = settings.get("location")
+                    if isinstance(location, Mapping):
+                        lat = location.get("lat")
+                        lon = location.get("lon")
+
+        if isinstance(lat, (int, float)) and isinstance(lon, (int, float)):
+            return {"lat": float(lat), "lon": float(lon)}
+        return None
+
+    @staticmethod
+    def _extract_taxonomy(items: Any) -> tuple[list[str], list[int]]:
+        names: List[str] = []
+        identifiers: List[int] = []
+        if isinstance(items, Iterable):
+            for item in items:
+                if isinstance(item, Mapping):
+                    name = item.get("name")
+                    if isinstance(name, str):
+                        names.append(name)
+                    identifier = item.get("id")
+                    if isinstance(identifier, int):
+                        identifiers.append(identifier)
+        return names, identifiers
+
+    @staticmethod
+    def _extract_languages(event: Mapping[str, Any]) -> List[str]:
+        languages: List[str] = []
+        default_locale = event.get("default_locale")
+        if isinstance(default_locale, str):
+            languages.append(default_locale)
+        translations = event.get("translations")
+        if isinstance(translations, Iterable):
+            for translation in translations:
+                if isinstance(translation, Mapping):
+                    locale = translation.get("locale")
+                    if isinstance(locale, str) and locale not in languages:
+                        languages.append(locale)
+        fallback = event.get("fallback_locale")
+        if isinstance(fallback, str) and fallback not in languages:
+            languages.append(fallback)
+        return languages

--- a/src/services/calendar.py
+++ b/src/services/calendar.py
@@ -1,0 +1,69 @@
+"""Utility helpers for exposing calendar feeds (iCal/ICS)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Iterable, Mapping
+
+__all__ = ["generate_ics_feed"]
+
+
+def generate_ics_feed(events: Iterable[Mapping], *, calendar_name: str = "Meetinity Events") -> str:
+    """Generate a minimal ICS document for the provided events."""
+
+    now = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//Meetinity//Event Service//FR",
+        f"X-WR-CALNAME:{_escape(calendar_name)}",
+        "CALSCALE:GREGORIAN",
+    ]
+
+    for event in events:
+        event_id = event.get("id")
+        title = event.get("title") or "Event"
+        description = event.get("description") or ""
+        event_date = event.get("date") or event.get("event_date")
+        if not isinstance(event_date, str):
+            continue
+        dtstart = event_date.replace("-", "")
+        dtend = (datetime.strptime(event_date, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y%m%d")
+        location = event.get("location") or ""
+        share = event.get("share") if isinstance(event.get("share"), Mapping) else None
+        url = share.get("url") if share else None
+        lines.extend(
+            [
+                "BEGIN:VEVENT",
+                f"UID:event-{event_id}@meetinity",
+                f"DTSTAMP:{now}",
+                f"DTSTART;VALUE=DATE:{dtstart}",
+                f"DTEND;VALUE=DATE:{dtend}",
+                f"SUMMARY:{_escape(title)}",
+                f"DESCRIPTION:{_escape(description)}",
+                f"LOCATION:{_escape(location)}",
+            ]
+        )
+        if url:
+            lines.append(f"URL:{_escape(url)}")
+        tags = event.get("tags")
+        if isinstance(tags, Iterable):
+            tag_values = []
+            for tag in tags:
+                name = tag.get("name") if isinstance(tag, Mapping) else tag
+                if isinstance(name, str):
+                    tag_values.append(name)
+            if tag_values:
+                lines.append(f"CATEGORIES:{_escape(','.join(tag_values))}")
+        lines.append("END:VEVENT")
+
+    lines.append("END:VCALENDAR")
+    return "\r\n".join(lines) + "\r\n"
+
+
+def _escape(value: str) -> str:
+    return (
+        value.replace("\\", "\\\\")
+        .replace(",", "\\,")
+        .replace(";", "\\;")
+        .replace("\n", "\\n")
+    )

--- a/src/services/recommendations.py
+++ b/src/services/recommendations.py
@@ -1,0 +1,236 @@
+"""Recommendation service combining user preferences with event metadata."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Protocol
+
+from .events import EventService
+from .search import EventSearchService
+
+__all__ = ["UserProfileClient", "RecommendationService", "UserProfile"]
+
+
+class UserProfileClient(Protocol):
+    """Protocol describing the minimal user profile client interface."""
+
+    def get_user_profile(self, user_id: str) -> Mapping[str, Any]:
+        ...
+
+
+@dataclass
+class UserProfile:
+    """Structured representation of a user profile used for recommendations."""
+
+    user_id: str
+    preferred_categories: List[str]
+    preferred_tags: List[str]
+    preferred_languages: List[str]
+    location: Optional[Dict[str, float]]
+    radius_km: Optional[float]
+    bookmarked_events: List[int]
+
+    @classmethod
+    def from_payload(cls, user_id: str, payload: Mapping[str, Any]) -> "UserProfile":
+        def _ensure_list(values: Any) -> List[str]:
+            if not values:
+                return []
+            if isinstance(values, str):
+                return [values]
+            if isinstance(values, Iterable):
+                return [str(value) for value in values if str(value).strip()]
+            return []
+
+        def _ensure_float(mapping: Mapping[str, Any], key: str) -> Optional[float]:
+            value = mapping.get(key)
+            if isinstance(value, (int, float)):
+                return float(value)
+            return None
+
+        location_payload = payload.get("location")
+        location = None
+        if isinstance(location_payload, Mapping):
+            lat = _ensure_float(location_payload, "lat")
+            lon = _ensure_float(location_payload, "lon")
+            if lat is not None and lon is not None:
+                location = {"lat": lat, "lon": lon}
+
+        radius = payload.get("radius_km")
+        if isinstance(radius, (int, float)):
+            radius_km = float(radius)
+        else:
+            radius_km = None
+
+        bookmarks: List[int] = []
+        if isinstance(payload.get("bookmarked_events"), Iterable):
+            for value in payload["bookmarked_events"]:
+                try:
+                    bookmarks.append(int(value))
+                except (TypeError, ValueError):
+                    continue
+
+        return cls(
+            user_id=user_id,
+            preferred_categories=_ensure_list(payload.get("preferred_categories")),
+            preferred_tags=_ensure_list(payload.get("preferred_tags")),
+            preferred_languages=_ensure_list(payload.get("preferred_languages")),
+            location=location,
+            radius_km=radius_km,
+            bookmarked_events=bookmarks,
+        )
+
+
+class RecommendationService:
+    """Provide personalised event recommendations for users."""
+
+    def __init__(
+        self,
+        event_service: EventService,
+        user_client: UserProfileClient,
+        *,
+        search_service: Optional[EventSearchService] = None,
+    ) -> None:
+        self.event_service = event_service
+        self.user_client = user_client
+        self.search_service = search_service
+
+    def get_recommendations(self, user_id: str, *, limit: int = 10) -> List[Dict[str, Any]]:
+        profile_payload = self.user_client.get_user_profile(user_id)
+        profile = UserProfile.from_payload(user_id, profile_payload)
+
+        # Start from the full list of events.
+        events = self.event_service.list_events()
+
+        # Optionally refine using the search service (leveraging geo filters).
+        if self.search_service and (profile.preferred_categories or profile.preferred_tags):
+            try:
+                search_results = self.search_service.search_events(
+                    categories=profile.preferred_categories,
+                    tags=profile.preferred_tags,
+                    languages=profile.preferred_languages,
+                    lat=profile.location["lat"] if profile.location else None,
+                    lon=profile.location["lon"] if profile.location else None,
+                    radius_km=profile.radius_km,
+                    size=limit * 3,
+                    include_suggestions=False,
+                )
+                if search_results.get("results"):
+                    events = search_results["results"]
+            except Exception:
+                # Fallback silently to local heuristics if the search backend fails.
+                pass
+
+        ranked = self._rank_events(events, profile)
+        filtered = [event for event in ranked if event["id"] not in profile.bookmarked_events]
+        return filtered[:limit]
+
+    # ------------------------------------------------------------------
+    # Ranking helpers
+    # ------------------------------------------------------------------
+    def _rank_events(self, events: Iterable[Mapping[str, Any]], profile: UserProfile) -> List[Dict[str, Any]]:
+        scored: List[tuple[float, Dict[str, Any]]] = []
+        for event in events:
+            if not isinstance(event, Mapping):
+                continue
+            event_id = event.get("id")
+            if event_id is None:
+                continue
+            score = 0.0
+            score += self._score_taxonomy(event.get("categories"), profile.preferred_categories, weight=3.0)
+            score += self._score_taxonomy(event.get("tags"), profile.preferred_tags, weight=2.0)
+            score += self._score_languages(event, profile.preferred_languages)
+            score += self._score_geo(event, profile)
+            if event.get("status") == "approved":
+                score += 0.5
+            bookmark_count = 0
+            if isinstance(event.get("settings"), Mapping):
+                bookmarks = event["settings"].get("bookmarks")
+                if isinstance(bookmarks, list):
+                    bookmark_count = len(bookmarks)
+            score += min(bookmark_count, 10) * 0.05
+            scored.append((score, dict(event)))
+        scored.sort(key=lambda item: (-item[0], item[1].get("date") or item[1].get("event_date") or ""))
+        return [item[1] for item in scored]
+
+    @staticmethod
+    def _score_taxonomy(items: Any, preferences: Iterable[str], *, weight: float) -> float:
+        if not items or not preferences:
+            return 0.0
+        available: List[str] = []
+        if isinstance(items, Iterable):
+            for item in items:
+                if isinstance(item, Mapping):
+                    name = item.get("name")
+                else:
+                    name = item
+                if isinstance(name, str):
+                    available.append(name.casefold())
+        preference_norm = [pref.casefold() for pref in preferences if isinstance(pref, str)]
+        matches = len([pref for pref in preference_norm if pref in available])
+        return matches * weight
+
+    @staticmethod
+    def _score_languages(event: Mapping[str, Any], preferences: Iterable[str]) -> float:
+        if not preferences:
+            return 0.0
+        locales: List[str] = []
+        default_locale = event.get("default_locale")
+        if isinstance(default_locale, str):
+            locales.append(default_locale.casefold())
+        translations = event.get("translations")
+        if isinstance(translations, Iterable):
+            for translation in translations:
+                if isinstance(translation, Mapping):
+                    locale = translation.get("locale")
+                    if isinstance(locale, str):
+                        locales.append(locale.casefold())
+        score = 0.0
+        for preference in preferences:
+            if isinstance(preference, str) and preference.casefold() in locales:
+                score += 1.0
+        return score
+
+    @staticmethod
+    def _score_geo(event: Mapping[str, Any], profile: UserProfile) -> float:
+        if not profile.location or not profile.radius_km:
+            return 0.0
+        coordinates = RecommendationService._extract_coordinates(event)
+        if not coordinates:
+            return 0.0
+        distance = RecommendationService._haversine_distance(
+            profile.location["lat"],
+            profile.location["lon"],
+            coordinates["lat"],
+            coordinates["lon"],
+        )
+        if distance > profile.radius_km:
+            return 0.0
+        return max(0.0, (profile.radius_km - distance) / profile.radius_km)
+
+    @staticmethod
+    def _extract_coordinates(event: Mapping[str, Any]) -> Optional[Dict[str, float]]:
+        settings = event.get("settings") if isinstance(event.get("settings"), Mapping) else None
+        if settings:
+            for key in ("coordinates", "geo", "location"):
+                candidate = settings.get(key)
+                if isinstance(candidate, Mapping):
+                    lat = candidate.get("lat")
+                    lon = candidate.get("lon") or candidate.get("lng")
+                    if isinstance(lat, (int, float)) and isinstance(lon, (int, float)):
+                        return {"lat": float(lat), "lon": float(lon)}
+        lat = event.get("latitude")
+        lon = event.get("longitude")
+        if isinstance(lat, (int, float)) and isinstance(lon, (int, float)):
+            return {"lat": float(lat), "lon": float(lon)}
+        return None
+
+    @staticmethod
+    def _haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+        from math import atan2, cos, radians, sin, sqrt
+
+        radius = 6371.0
+        phi1, phi2 = radians(lat1), radians(lat2)
+        d_phi = radians(lat2 - lat1)
+        d_lambda = radians(lon2 - lon1)
+        a = sin(d_phi / 2) ** 2 + cos(phi1) * cos(phi2) * sin(d_lambda / 2) ** 2
+        c = 2 * atan2(sqrt(a), sqrt(1 - a))
+        return radius * c

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -1,0 +1,422 @@
+"""Search service wrapping Elasticsearch queries with graceful fallbacks."""
+from __future__ import annotations
+
+import math
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional
+
+__all__ = ["EventSearchService", "SearchError"]
+
+
+class SearchError(RuntimeError):
+    """Raised when the search backend cannot satisfy a request."""
+
+
+class EventSearchService:
+    """High level helper orchestrating search queries for events."""
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        index_name: str = "events",
+        event_provider: Optional[Callable[[], Iterable[Dict[str, Any]]]] = None,
+    ) -> None:
+        self.client = client
+        self.index_name = index_name
+        self.event_provider = event_provider or (lambda: [])
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def search_events(
+        self,
+        *,
+        text: Optional[str] = None,
+        categories: Optional[Iterable[str]] = None,
+        tags: Optional[Iterable[str]] = None,
+        languages: Optional[Iterable[str]] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        lat: Optional[float] = None,
+        lon: Optional[float] = None,
+        radius_km: Optional[float] = None,
+        page: int = 1,
+        size: int = 20,
+        sort: Optional[str] = None,
+        include_suggestions: bool = True,
+    ) -> Dict[str, Any]:
+        """Execute a search query.
+
+        When an Elasticsearch client is configured, the query is delegated to it.
+        Otherwise a best-effort in-memory filtering strategy is applied on the
+        dataset returned by ``event_provider``.
+        """
+
+        page = max(1, page)
+        size = max(1, min(size, 100))
+        categories_list = self._normalise_iterable(categories)
+        tags_list = self._normalise_iterable(tags)
+        languages_list = self._normalise_iterable(languages)
+
+        if self.client and hasattr(self.client, "search"):
+            body = self._build_elasticsearch_query(
+                text=text,
+                categories=categories_list,
+                tags=tags_list,
+                languages=languages_list,
+                start_date=start_date,
+                end_date=end_date,
+                lat=lat,
+                lon=lon,
+                radius_km=radius_km,
+                from_=(page - 1) * size,
+                size=size,
+                sort=sort,
+                include_suggestions=include_suggestions,
+            )
+            response = self.client.search(index=self.index_name, **body)
+            return self._format_es_response(response, page=page, size=size)
+
+        # Fallback search strategy when no ES client is available.
+        events = list(self.event_provider())
+        results = self._filter_events(
+            events,
+            text=text,
+            categories=categories_list,
+            tags=tags_list,
+            languages=languages_list,
+            start_date=start_date,
+            end_date=end_date,
+            lat=lat,
+            lon=lon,
+            radius_km=radius_km,
+        )
+        sorted_results = self._sort_results(results, sort)
+        total = len(sorted_results)
+        start = (page - 1) * size
+        end = start + size
+        return {
+            "results": sorted_results[start:end],
+            "total": total,
+            "page": page,
+            "size": size,
+            "suggestions": self._build_suggestions(text, sorted_results)
+            if include_suggestions
+            else [],
+        }
+
+    # ------------------------------------------------------------------
+    # Elasticsearch helpers
+    # ------------------------------------------------------------------
+    def _build_elasticsearch_query(
+        self,
+        *,
+        text: Optional[str],
+        categories: List[str],
+        tags: List[str],
+        languages: List[str],
+        start_date: Optional[str],
+        end_date: Optional[str],
+        lat: Optional[float],
+        lon: Optional[float],
+        radius_km: Optional[float],
+        from_: int,
+        size: int,
+        sort: Optional[str],
+        include_suggestions: bool,
+    ) -> Dict[str, Any]:
+        query: Dict[str, Any] = {"bool": {"must": [], "filter": []}}
+
+        if text:
+            query["bool"]["must"].append(
+                {
+                    "multi_match": {
+                        "query": text,
+                        "fields": ["title^3", "description", "tags", "categories"],
+                    }
+                }
+            )
+        if categories:
+            query["bool"]["filter"].append({"terms": {"categories.keyword": categories}})
+        if tags:
+            query["bool"]["filter"].append({"terms": {"tags.keyword": tags}})
+        if languages:
+            query["bool"]["filter"].append({"terms": {"languages": languages}})
+        if start_date or end_date:
+            range_filter: Dict[str, Any] = {}
+            if start_date:
+                range_filter["gte"] = start_date
+            if end_date:
+                range_filter["lte"] = end_date
+            query["bool"]["filter"].append({"range": {"event_date": range_filter}})
+        if lat is not None and lon is not None and radius_km:
+            query["bool"]["filter"].append(
+                {
+                    "geo_distance": {
+                        "distance": f"{radius_km}km",
+                        "coordinates": {"lat": lat, "lon": lon},
+                    }
+                }
+            )
+
+        if not query["bool"]["must"] and not query["bool"]["filter"]:
+            final_query: Dict[str, Any] = {"match_all": {}}
+        else:
+            final_query = query
+
+        body: Dict[str, Any] = {"query": final_query, "from": from_, "size": size}
+
+        if sort:
+            body["sort"] = [self._translate_sort(sort)]
+        if include_suggestions and text:
+            body["suggest"] = {
+                "event-suggest": {
+                    "text": text,
+                    "term": {"field": "title"},
+                }
+            }
+        return body
+
+    def _format_es_response(self, response: Mapping[str, Any], *, page: int, size: int) -> Dict[str, Any]:
+        hits = response.get("hits", {}) if isinstance(response, Mapping) else {}
+        total_value = hits.get("total", {}).get("value") if isinstance(hits, Mapping) else None
+        results = []
+        hit_items = hits.get("hits") if isinstance(hits, Mapping) else []
+        if isinstance(hit_items, Iterable):
+            for item in hit_items:
+                if isinstance(item, Mapping):
+                    source = item.get("_source")
+                    if isinstance(source, Mapping):
+                        results.append(dict(source))
+        suggestions: List[str] = []
+        suggest = response.get("suggest") if isinstance(response, Mapping) else None
+        if isinstance(suggest, Mapping):
+            for value in suggest.values():
+                if isinstance(value, Iterable):
+                    for entry in value:
+                        options = entry.get("options") if isinstance(entry, Mapping) else None
+                        if isinstance(options, Iterable):
+                            for option in options:
+                                text = option.get("text") if isinstance(option, Mapping) else None
+                                if isinstance(text, str) and text not in suggestions:
+                                    suggestions.append(text)
+        return {
+            "results": results,
+            "total": total_value if isinstance(total_value, int) else len(results),
+            "page": page,
+            "size": size,
+            "suggestions": suggestions,
+        }
+
+    @staticmethod
+    def _translate_sort(sort: str) -> Dict[str, Any]:
+        field = sort
+        order = "asc"
+        if sort.startswith("-"):
+            field = sort[1:]
+            order = "desc"
+        mapping = {
+            "date": "event_date",
+            "attendees": "attendees",
+        }
+        es_field = mapping.get(field, field)
+        return {es_field: {"order": order}}
+
+    # ------------------------------------------------------------------
+    # Fallback search helpers
+    # ------------------------------------------------------------------
+    def _filter_events(
+        self,
+        events: List[Dict[str, Any]],
+        *,
+        text: Optional[str],
+        categories: List[str],
+        tags: List[str],
+        languages: List[str],
+        start_date: Optional[str],
+        end_date: Optional[str],
+        lat: Optional[float],
+        lon: Optional[float],
+        radius_km: Optional[float],
+    ) -> List[Dict[str, Any]]:
+        filtered: List[Dict[str, Any]] = []
+        for event in events:
+            if not isinstance(event, Mapping):
+                continue
+            if text and not self._matches_text(event, text):
+                continue
+            if categories and not self._matches_taxonomy(event.get("categories"), categories):
+                continue
+            if tags and not self._matches_taxonomy(event.get("tags"), tags):
+                continue
+            if languages and not self._matches_languages(event, languages):
+                continue
+            if not self._matches_date_range(event, start_date, end_date):
+                continue
+            if radius_km and not self._matches_geo(event, lat, lon, radius_km):
+                continue
+            filtered.append(dict(event))
+        return filtered
+
+    def _sort_results(self, results: List[Dict[str, Any]], sort: Optional[str]) -> List[Dict[str, Any]]:
+        if not sort:
+            return sorted(results, key=lambda event: event.get("date") or "")
+        reverse = sort.startswith("-")
+        key = sort[1:] if reverse else sort
+
+        def sort_key(event: Mapping[str, Any]) -> Any:
+            if key == "date":
+                return event.get("date") or event.get("event_date") or ""
+            if key == "attendees":
+                return event.get("attendees", 0)
+            return event.get(key)
+
+        return sorted(results, key=sort_key, reverse=reverse)
+
+    @staticmethod
+    def _build_suggestions(text: Optional[str], results: List[Dict[str, Any]]) -> List[str]:
+        if not text:
+            return []
+        suggestions: List[str] = []
+        lowered = text.casefold()
+        for event in results:
+            title = event.get("title")
+            if isinstance(title, str) and lowered in title.casefold():
+                if title not in suggestions:
+                    suggestions.append(title)
+        return suggestions[:5]
+
+    # ------------------------------------------------------------------
+    # Matching helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalise_iterable(values: Optional[Iterable[str]]) -> List[str]:
+        if not values:
+            return []
+        return [str(value).strip() for value in values if str(value).strip()]
+
+    @staticmethod
+    def _matches_text(event: Mapping[str, Any], text: str) -> bool:
+        lowered = text.casefold()
+        for field in ("title", "description", "location", "type"):
+            value = event.get(field)
+            if isinstance(value, str) and lowered in value.casefold():
+                return True
+        tags = event.get("tags")
+        if isinstance(tags, Iterable):
+            for tag in tags:
+                if isinstance(tag, Mapping):
+                    name = tag.get("name")
+                else:
+                    name = tag
+                if isinstance(name, str) and lowered in name.casefold():
+                    return True
+        categories = event.get("categories")
+        if isinstance(categories, Iterable):
+            for category in categories:
+                if isinstance(category, Mapping):
+                    name = category.get("name")
+                else:
+                    name = category
+                if isinstance(name, str) and lowered in name.casefold():
+                    return True
+        return False
+
+    @staticmethod
+    def _matches_taxonomy(items: Any, expected: List[str]) -> bool:
+        if not items:
+            return False
+        available: List[str] = []
+        if isinstance(items, Iterable):
+            for item in items:
+                if isinstance(item, Mapping):
+                    name = item.get("name")
+                else:
+                    name = item
+                if isinstance(name, str):
+                    available.append(name.casefold())
+        expected_norm = [value.casefold() for value in expected]
+        return any(value in available for value in expected_norm)
+
+    @staticmethod
+    def _matches_languages(event: Mapping[str, Any], expected: List[str]) -> bool:
+        locales: List[str] = []
+        default_locale = event.get("default_locale")
+        if isinstance(default_locale, str):
+            locales.append(default_locale.casefold())
+        translations = event.get("translations")
+        if isinstance(translations, Iterable):
+            for translation in translations:
+                if isinstance(translation, Mapping):
+                    locale = translation.get("locale")
+                    if isinstance(locale, str):
+                        locales.append(locale.casefold())
+        fallback = event.get("fallback_locale")
+        if isinstance(fallback, str):
+            locales.append(fallback.casefold())
+        expected_norm = [value.casefold() for value in expected]
+        return any(value in locales for value in expected_norm)
+
+    @staticmethod
+    def _matches_date_range(
+        event: Mapping[str, Any], start_date: Optional[str], end_date: Optional[str]
+    ) -> bool:
+        event_date = event.get("date") or event.get("event_date")
+        if not (start_date or end_date) or not isinstance(event_date, str):
+            return True
+        if start_date and event_date < start_date:
+            return False
+        if end_date and event_date > end_date:
+            return False
+        return True
+
+    def _matches_geo(
+        self,
+        event: Mapping[str, Any],
+        lat: Optional[float],
+        lon: Optional[float],
+        radius_km: float,
+    ) -> bool:
+        if lat is None or lon is None:
+            return True
+        coordinates = self._extract_coordinates(event)
+        if not coordinates:
+            return False
+        distance = self._haversine_distance(lat, lon, coordinates["lat"], coordinates["lon"])
+        return distance <= radius_km
+
+    @staticmethod
+    def _extract_coordinates(event: Mapping[str, Any]) -> Optional[Dict[str, float]]:
+        settings = event.get("settings") if isinstance(event.get("settings"), Mapping) else None
+        candidates: List[Mapping[str, Any]] = []
+        if settings:
+            for key in ("coordinates", "geo"):
+                value = settings.get(key)
+                if isinstance(value, Mapping):
+                    candidates.append(value)
+            location = settings.get("location")
+            if isinstance(location, Mapping):
+                candidates.append(location)
+        lat = event.get("latitude")
+        lon = event.get("longitude")
+        if isinstance(lat, (int, float)) and isinstance(lon, (int, float)):
+            return {"lat": float(lat), "lon": float(lon)}
+        for candidate in candidates:
+            c_lat = candidate.get("lat")
+            c_lon = candidate.get("lon") or candidate.get("lng")
+            if isinstance(c_lat, (int, float)) and isinstance(c_lon, (int, float)):
+                return {"lat": float(c_lat), "lon": float(c_lon)}
+        return None
+
+    @staticmethod
+    def _haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+        radius = 6371.0
+        phi1, phi2 = math.radians(lat1), math.radians(lat2)
+        d_phi = math.radians(lat2 - lat1)
+        d_lambda = math.radians(lon2 - lon1)
+        a = (
+            math.sin(d_phi / 2) ** 2
+            + math.cos(phi1) * math.cos(phi2) * math.sin(d_lambda / 2) ** 2
+        )
+        c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+        return radius * c

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-import os
 import sys
 from pathlib import Path
 
@@ -10,6 +9,24 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from src.database import Base, get_engine, get_session, init_engine
 from src.main import app
 from src.services.events import EventService
+
+
+class StubUserProfileClient:
+    def __init__(self):
+        self.profiles = {
+            "user-geo": {
+                "preferred_categories": ["Tech"],
+                "preferred_tags": ["python"],
+                "preferred_languages": ["fr-FR", "en-US"],
+                "location": {"lat": 48.8566, "lon": 2.3522},
+                "radius_km": 500,
+                "bookmarked_events": [],
+            }
+        }
+
+    def get_user_profile(self, user_id: str):
+        return self.profiles.get(user_id, {})
+
 
 DEFAULT_EVENTS = [
     {
@@ -68,5 +85,8 @@ def seed_default_events():
 @pytest.fixture
 def client(seed_default_events):
     app.config["TESTING"] = True
+    app.config["EVENTS_INDEX"] = "events-test"
+    app.config["SEARCH_CLIENT"] = None
+    app.config["USER_PROFILE_CLIENT"] = StubUserProfileClient()
     with app.test_client() as client:
         yield client

--- a/tests/test_search_and_recommendations.py
+++ b/tests/test_search_and_recommendations.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from src.database import get_session
+from src.search.indexer import EventIndexer
+from src.services.events import EventService
+from src.services.search import EventSearchService
+
+
+class StubElasticsearchClient:
+    def __init__(self) -> None:
+        self.index_calls: List[Dict[str, Any]] = []
+        self.bulk_calls: List[Dict[str, Any]] = []
+        self.delete_calls: List[Dict[str, Any]] = []
+
+    def index(self, **kwargs):
+        self.index_calls.append(kwargs)
+        return {"result": "created"}
+
+    def bulk(self, **kwargs):
+        self.bulk_calls.append(kwargs)
+        return {"errors": False}
+
+    def delete(self, **kwargs):
+        self.delete_calls.append(kwargs)
+        return {"result": "deleted"}
+
+
+def test_event_indexer_builds_document():
+    client = StubElasticsearchClient()
+    indexer = EventIndexer(client, index_name="events-test")
+    event = {
+        "id": 99,
+        "title": "Global Tech Summit",
+        "description": "Conférence internationale",
+        "date": "2025-10-10",
+        "timezone": "Europe/Paris",
+        "location": "Paris",
+        "default_locale": "fr-FR",
+        "fallback_locale": "en-US",
+        "categories": [{"id": 1, "name": "Tech"}],
+        "tags": [{"id": 1, "name": "innovation"}],
+        "translations": [
+            {"locale": "fr-FR", "title": "Sommet Tech"},
+            {"locale": "en-US", "title": "Tech Summit"},
+        ],
+        "settings": {"coordinates": {"lat": 48.8566, "lon": 2.3522}},
+        "share": {"url": "https://example.com/events/99"},
+    }
+
+    document = indexer.build_document(event)
+    assert document.coordinates == {"lat": 48.8566, "lon": 2.3522}
+    assert sorted(document.languages) == ["en-US", "fr-FR"]
+    indexer.index_event(event, refresh=True)
+    assert client.index_calls
+    stored_document = client.index_calls[0]["document"]
+    assert stored_document["coordinates"] == {"lat": 48.8566, "lon": 2.3522}
+    assert "indexed_at" in stored_document
+
+    indexer.bulk_index_events([event])
+    assert client.bulk_calls
+
+
+def test_search_service_combined_filters():
+    events = [
+        {
+            "id": 1,
+            "title": "Geo Python Paris",
+            "description": "Meetup python",
+            "date": "2025-09-10",
+            "categories": [{"name": "Tech"}],
+            "tags": [{"name": "python"}],
+            "translations": [{"locale": "fr-FR"}],
+            "settings": {"coordinates": {"lat": 48.8566, "lon": 2.3522}},
+        },
+        {
+            "id": 2,
+            "title": "Remote Marketing Webinar",
+            "description": "Webinar",
+            "date": "2025-09-12",
+            "categories": [{"name": "Marketing"}],
+            "tags": [{"name": "digital"}],
+            "translations": [{"locale": "en-US"}],
+            "settings": {"coordinates": {"lat": 45.764, "lon": 4.8357}},
+        },
+    ]
+
+    service = EventSearchService(client=None, event_provider=lambda: events)
+    results = service.search_events(
+        text="python",
+        categories=["Tech"],
+        tags=["python"],
+        languages=["fr-FR"],
+        lat=48.8566,
+        lon=2.3522,
+        radius_km=100,
+        page=1,
+        size=10,
+    )
+
+    assert results["total"] == 1
+    assert results["results"][0]["id"] == 1
+    assert any("Geo" in suggestion for suggestion in results["suggestions"])
+
+
+def test_bookmark_recommendations_and_map(client):
+    session = get_session()
+    service = EventService(session)
+    try:
+        event = service.create_event(
+            {
+                "title": "Geo Python Paris",
+                "date": "2025-09-10",
+                "location": "Paris",
+                "default_locale": "fr-FR",
+                "settings": {"coordinates": {"lat": 48.8566, "lon": 2.3522}},
+                "translations": [
+                    {
+                        "locale": "fr-FR",
+                        "title": "Geo Python Paris",
+                        "description": "Rencontre autour de Python",
+                    }
+                ],
+            }
+        )
+        event_id = event["id"]
+    finally:
+        session.close()
+
+    search_resp = client.get(
+        "/search/events",
+        query_string={
+            "q": "Python",
+            "language": "fr-FR",
+            "lat": "48.8566",
+            "lon": "2.3522",
+            "radius": "50",
+        },
+    )
+    assert search_resp.status_code == 200
+    search_ids = [item["id"] for item in search_resp.json["results"]]
+    assert event_id in search_ids
+
+    map_resp = client.get("/events/map")
+    assert map_resp.status_code == 200
+    feature_ids = [feature["properties"]["id"] for feature in map_resp.json["features"]]
+    assert event_id in feature_ids
+
+    calendar_resp = client.get("/events/calendar")
+    assert calendar_resp.status_code == 200
+    assert calendar_resp.mimetype == "text/calendar"
+    assert "Geo Python Paris" in calendar_resp.data.decode()
+
+    recommendations_resp = client.get("/users/user-geo/recommendations")
+    assert recommendations_resp.status_code == 200
+    recommended_ids = [item["id"] for item in recommendations_resp.json["recommendations"]]
+    assert event_id in recommended_ids
+
+    bookmark_resp = client.post(f"/events/{event_id}/bookmark", json={"user_id": "user-geo"})
+    assert bookmark_resp.status_code == 201
+    assert bookmark_resp.json["bookmark"]["bookmarked"] is True
+
+    list_resp = client.get(f"/events/{event_id}/bookmark")
+    assert list_resp.status_code == 200
+    assert list_resp.json["total"] == 1
+
+    recommendations_after = client.get("/users/user-geo/recommendations")
+    ids_after = [item["id"] for item in recommendations_after.json["recommendations"]]
+    assert event_id not in ids_after


### PR DESCRIPTION
## Summary
- add an Elasticsearch indexer module and search service to support geo-aware queries and suggestions
- extend event routes and services with calendar feeds, map discovery, bookmarking, and share metadata
- expose recommendation and search APIs and add tests covering indexing, search, bookmarking, and recommendations

## Testing
- pytest *(fails: SQLAlchemy dependency unavailable in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d99fe734e8833281fb023e2d4fbd0b