### PR TITLE
Add networking and engagement features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask==3.0.0
 Flask-CORS==4.0.0
+Flask-SocketIO==5.3.6
 SQLAlchemy==2.0.21
 psycopg2-binary==2.9.9
 alembic==1.12.1

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,39 @@
 """Meetinity Event Service application entrypoint."""
 from __future__ import annotations
 
+from datetime import datetime
+from typing import Optional
+
 from flask import Flask, g, jsonify, request
+
+try:
+    from flask_socketio import SocketIO, emit, join_room, leave_room
+except ModuleNotFoundError:  # pragma: no cover - fallback for offline environments
+    class SocketIO:  # type: ignore[override]
+        def __init__(self, *args, **kwargs):
+            self._handlers = {}
+
+        def init_app(self, *args, **kwargs):
+            return None
+
+        def on(self, event_name):
+            def decorator(func):
+                self._handlers[event_name] = func
+                return func
+
+            return decorator
+
+        def emit(self, *args, **kwargs):
+            return None
+
+    def emit(*args, **kwargs):  # type: ignore[misc]
+        return None
+
+    def join_room(*args, **kwargs):  # type: ignore[misc]
+        return None
+
+    def leave_room(*args, **kwargs):  # type: ignore[misc]
+        return None
 
 from src.database import get_session, init_engine
 from src.routes import register_blueprints
@@ -17,6 +49,8 @@ from src.services.registrations import (
 )
 
 app = Flask(__name__)
+socketio = SocketIO(cors_allowed_origins="*")
+_SOCKET_HANDLERS_REGISTERED = False
 
 
 def create_app() -> Flask:
@@ -24,6 +58,8 @@ def create_app() -> Flask:
     register_blueprints(app)
     app.teardown_appcontext(cleanup_services)
     register_error_handlers(app)
+    socketio.init_app(app, cors_allowed_origins="*")
+    _register_socketio_handlers()
     return app
 
 
@@ -79,6 +115,120 @@ def register_error_handlers(flask_app: Flask) -> None:
     @flask_app.errorhandler(500)
     def handle_500(e):
         return error_response(500, "Erreur interne. On respire, on relance.")
+
+
+def _register_socketio_handlers() -> None:
+    global _SOCKET_HANDLERS_REGISTERED
+    if _SOCKET_HANDLERS_REGISTERED:
+        return
+
+    @socketio.on("join_event")
+    def handle_join_event(data):  # type: ignore[misc]
+        event_id = _extract_event_id(data)
+        if event_id is None:
+            emit(
+                "event:error",
+                {"message": "event_id requis pour rejoindre un canal."},
+            )
+            return
+        room = _event_room(event_id)
+        join_room(room)
+        emit(
+            "event:presence",
+            {
+                "event_id": event_id,
+                "type": "join",
+                "user": (data or {}).get("user"),
+                "timestamp": _timestamp(),
+            },
+            room=room,
+        )
+
+    @socketio.on("leave_event")
+    def handle_leave_event(data):  # type: ignore[misc]
+        event_id = _extract_event_id(data)
+        if event_id is None:
+            return
+        room = _event_room(event_id)
+        leave_room(room)
+        emit(
+            "event:presence",
+            {
+                "event_id": event_id,
+                "type": "leave",
+                "user": (data or {}).get("user"),
+                "timestamp": _timestamp(),
+            },
+            room=room,
+        )
+
+    @socketio.on("send_announcement")
+    def handle_send_announcement(data):  # type: ignore[misc]
+        if not isinstance(data, dict):
+            return
+        payload = {
+            "event_id": data.get("event_id"),
+            "message": data.get("message"),
+            "title": data.get("title"),
+            "timestamp": _timestamp(),
+        }
+        event_id = _extract_event_id(data)
+        if event_id is None:
+            socketio.emit("event:announcement", payload)
+        else:
+            emit("event:announcement", payload, room=_event_room(event_id))
+
+    @socketio.on("agenda_notification")
+    def handle_agenda_notification(data):  # type: ignore[misc]
+        if not isinstance(data, dict):
+            return
+        event_id = _extract_event_id(data)
+        if event_id is None:
+            return
+        payload = {
+            "event_id": event_id,
+            "slot": data.get("slot"),
+            "message": data.get("message"),
+            "timestamp": _timestamp(),
+        }
+        emit("event:agenda", payload, room=_event_room(event_id))
+
+    @socketio.on("chat_message")
+    def handle_chat_message(data):  # type: ignore[misc]
+        if not isinstance(data, dict):
+            return
+        event_id = _extract_event_id(data)
+        if event_id is None or not data.get("message"):
+            return
+        payload = {
+            "event_id": event_id,
+            "user": data.get("user"),
+            "message": data.get("message"),
+            "timestamp": _timestamp(),
+        }
+        emit("event:chat", payload, room=_event_room(event_id))
+
+    _SOCKET_HANDLERS_REGISTERED = True
+
+
+def _extract_event_id(data) -> Optional[int]:
+    if not isinstance(data, dict):
+        return None
+    event_id = data.get("event_id")
+    if isinstance(event_id, int):
+        return event_id
+    try:
+        return int(event_id)
+    except (TypeError, ValueError):
+        return None
+
+
+def _event_room(event_id: int) -> str:
+    return f"event-{event_id}"
+
+
+def _timestamp() -> str:
+    return datetime.utcnow().isoformat() + "Z"
 
 
 @app.route("/events", methods=["POST"])

--- a/src/repositories/events.py
+++ b/src/repositories/events.py
@@ -14,9 +14,13 @@ from src.models import (
     EventCategory,
     EventNotification,
     EventSeries,
+    EventSpeaker,
+    EventSponsor,
     EventTag,
     EventTemplate,
     EventTranslation,
+    NetworkingSuggestion,
+    ParticipantProfile,
 )
 
 
@@ -42,6 +46,12 @@ class EventRepository:
                 selectinload(Event.categories),
                 selectinload(Event.tags),
                 selectinload(Event.translations),
+                selectinload(Event.participant_profiles),
+                selectinload(Event.networking_suggestions)
+                .joinedload(NetworkingSuggestion.suggested_participant),
+                selectinload(Event.feedback_entries),
+                selectinload(Event.speaker_profiles),
+                selectinload(Event.sponsors),
             )
             .order_by(Event.event_date.asc(), Event.id.asc())
         )
@@ -67,6 +77,12 @@ class EventRepository:
                 selectinload(Event.categories),
                 selectinload(Event.tags),
                 selectinload(Event.translations),
+                selectinload(Event.participant_profiles),
+                selectinload(Event.networking_suggestions)
+                .joinedload(NetworkingSuggestion.suggested_participant),
+                selectinload(Event.feedback_entries),
+                selectinload(Event.speaker_profiles),
+                selectinload(Event.sponsors),
             )
             .where(Event.id == event_id)
         )
@@ -85,6 +101,13 @@ class EventRepository:
         attendees: int,
         timezone: str,
         status: str,
+        event_format: str,
+        streaming_url: Optional[str],
+        virtual_platform: Optional[str],
+        virtual_access_instructions: Optional[str],
+        secure_access_token: Optional[str],
+        rtmp_ingest_url: Optional[str],
+        rtmp_stream_key: Optional[str],
         capacity_limit: Optional[int],
         recurrence_rule: Optional[str],
         default_locale: str,
@@ -104,6 +127,13 @@ class EventRepository:
             attendees=attendees,
             timezone=timezone,
             status=status,
+            event_format=event_format,
+            streaming_url=streaming_url,
+            virtual_platform=virtual_platform,
+            virtual_access_instructions=virtual_access_instructions,
+            secure_access_token=secure_access_token,
+            rtmp_ingest_url=rtmp_ingest_url,
+            rtmp_stream_key=rtmp_stream_key,
             capacity_limit=capacity_limit,
             recurrence_rule=recurrence_rule,
             default_locale=default_locale,

--- a/src/repositories/feedback.py
+++ b/src/repositories/feedback.py
@@ -1,0 +1,101 @@
+"""Repository helpers for managing event feedback."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, Optional, Sequence
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from src.models import EventFeedback
+
+
+class FeedbackRepository:
+    """Persistence operations for event feedback entries."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def create(
+        self,
+        *,
+        event_id: int,
+        participant_email: Optional[str],
+        participant_name: Optional[str],
+        rating: int,
+        comment: Optional[str],
+        sentiment: Optional[str],
+        metadata: Optional[dict],
+    ) -> EventFeedback:
+        feedback = EventFeedback(
+            event_id=event_id,
+            participant_email=participant_email,
+            participant_name=participant_name,
+            rating=rating,
+            comment=comment,
+            sentiment=sentiment,
+            metadata=metadata,
+        )
+        self.session.add(feedback)
+        self.session.flush()
+        self.session.refresh(feedback)
+        return feedback
+
+    def list_for_event(self, event_id: int) -> Sequence[EventFeedback]:
+        query = (
+            select(EventFeedback)
+            .where(EventFeedback.event_id == event_id)
+            .order_by(EventFeedback.created_at.desc())
+        )
+        return self.session.scalars(query).all()
+
+    def get(self, event_id: int, feedback_id: int) -> EventFeedback:
+        feedback = self.session.get(EventFeedback, feedback_id)
+        if feedback is None or feedback.event_id != event_id:
+            raise LookupError(f"Feedback {feedback_id} introuvable pour l'événement {event_id}")
+        return feedback
+
+    def update_status(
+        self,
+        feedback: EventFeedback,
+        *,
+        status: str,
+        moderator: Optional[str],
+    ) -> EventFeedback:
+        feedback.status = status
+        feedback.moderated_by = moderator
+        if moderator:
+            feedback.moderated_at = datetime.now(timezone.utc)
+        else:
+            feedback.moderated_at = None
+        self.session.flush()
+        self.session.refresh(feedback)
+        return feedback
+
+    def aggregates(self, event_id: int) -> Dict[str, float]:
+        base_query = select(
+            func.count(EventFeedback.id),
+            func.avg(EventFeedback.rating),
+        ).where(EventFeedback.event_id == event_id)
+        total, average = self.session.execute(base_query).one()
+
+        breakdown_query = select(
+            EventFeedback.rating,
+            func.count(EventFeedback.id),
+        ).where(EventFeedback.event_id == event_id)
+        breakdown_query = breakdown_query.group_by(EventFeedback.rating)
+        breakdown_rows = self.session.execute(breakdown_query).all()
+        breakdown = {row[0]: row[1] for row in breakdown_rows}
+
+        pending_query = select(func.count(EventFeedback.id)).where(
+            EventFeedback.event_id == event_id,
+            EventFeedback.status == "pending",
+        )
+        pending_total = self.session.execute(pending_query).scalar_one()
+
+        return {
+            "total": int(total or 0),
+            "average": float(average or 0.0),
+            "breakdown": {int(k): int(v) for k, v in breakdown.items()},
+            "pending": int(pending_total or 0),
+        }

--- a/src/repositories/networking.py
+++ b/src/repositories/networking.py
@@ -1,0 +1,143 @@
+"""Repositories for networking and participant collaboration features."""
+from __future__ import annotations
+
+from typing import Iterable, Optional, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models import NetworkingSuggestion, ParticipantProfile
+
+
+class ParticipantProfileRepository:
+    """Persistence utilities for participant networking profiles."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def upsert(
+        self,
+        *,
+        event_id: int,
+        attendee_email: str,
+        attendee_name: Optional[str],
+        company: Optional[str],
+        bio: Optional[str],
+        headline: Optional[str],
+        interests: Optional[dict],
+        goals: Optional[dict],
+        availability: Optional[dict],
+        metadata: Optional[dict],
+    ) -> ParticipantProfile:
+        profile = self.get_by_event_and_email(event_id, attendee_email)
+        if profile is None:
+            profile = ParticipantProfile(
+                event_id=event_id,
+                attendee_email=attendee_email,
+            )
+            self.session.add(profile)
+
+        profile.attendee_name = attendee_name
+        profile.company = company
+        profile.bio = bio
+        profile.headline = headline
+        profile.interests = interests
+        profile.goals = goals
+        profile.availability = availability
+        profile.metadata = metadata
+        self.session.flush()
+        self.session.refresh(profile)
+        return profile
+
+    def list_for_event(self, event_id: int) -> Sequence[ParticipantProfile]:
+        query = (
+            select(ParticipantProfile)
+            .where(ParticipantProfile.event_id == event_id)
+            .order_by(ParticipantProfile.attendee_name.asc())
+        )
+        return self.session.scalars(query).all()
+
+    def get_by_event_and_email(
+        self, event_id: int, attendee_email: str
+    ) -> Optional[ParticipantProfile]:
+        query = (
+            select(ParticipantProfile)
+            .where(ParticipantProfile.event_id == event_id)
+            .where(ParticipantProfile.attendee_email == attendee_email)
+        )
+        return self.session.scalars(query).first()
+
+    def get(self, profile_id: int) -> ParticipantProfile:
+        profile = self.session.get(ParticipantProfile, profile_id)
+        if profile is None:
+            raise LookupError(f"Participant profile {profile_id} not found")
+        return profile
+
+
+class NetworkingSuggestionRepository:
+    """Persistence helper for networking suggestions."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def upsert(
+        self,
+        *,
+        event_id: int,
+        participant_id: int,
+        suggested_participant_id: int,
+        score: float,
+        rationale: Optional[str],
+        metadata: Optional[dict],
+        status: Optional[str] = None,
+    ) -> NetworkingSuggestion:
+        query = (
+            select(NetworkingSuggestion)
+            .where(NetworkingSuggestion.participant_id == participant_id)
+            .where(
+                NetworkingSuggestion.suggested_participant_id
+                == suggested_participant_id
+            )
+        )
+        suggestion = self.session.scalars(query).first()
+        if suggestion is None:
+            suggestion = NetworkingSuggestion(
+                event_id=event_id,
+                participant_id=participant_id,
+                suggested_participant_id=suggested_participant_id,
+            )
+            self.session.add(suggestion)
+
+        suggestion.score = score
+        suggestion.rationale = rationale
+        suggestion.metadata = metadata
+        if status is not None:
+            suggestion.status = status
+        self.session.flush()
+        self.session.refresh(suggestion)
+        return suggestion
+
+    def list_for_participant(
+        self, participant_id: int, *, statuses: Optional[Iterable[str]] = None
+    ) -> Sequence[NetworkingSuggestion]:
+        query = select(NetworkingSuggestion).where(
+            NetworkingSuggestion.participant_id == participant_id
+        )
+        if statuses is not None:
+            query = query.where(NetworkingSuggestion.status.in_(list(statuses)))
+        query = query.order_by(NetworkingSuggestion.score.desc())
+        return self.session.scalars(query).all()
+
+    def list_for_event(self, event_id: int) -> Sequence[NetworkingSuggestion]:
+        query = (
+            select(NetworkingSuggestion)
+            .where(NetworkingSuggestion.event_id == event_id)
+            .order_by(NetworkingSuggestion.score.desc())
+        )
+        return self.session.scalars(query).all()
+
+    def get(self, suggestion_id: int) -> NetworkingSuggestion:
+        suggestion = self.session.get(NetworkingSuggestion, suggestion_id)
+        if suggestion is None:
+            raise LookupError(f"Networking suggestion {suggestion_id} not found")
+        return suggestion

--- a/src/repositories/partners.py
+++ b/src/repositories/partners.py
@@ -1,0 +1,132 @@
+"""Repositories handling speakers, organisers and sponsors."""
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models import EventSpeaker, EventSponsor
+
+
+class EventSpeakerRepository:
+    """Manage event speakers and organisers."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def create(
+        self,
+        *,
+        event_id: int,
+        full_name: str,
+        role: str,
+        title: Optional[str],
+        company: Optional[str],
+        bio: Optional[str],
+        topics: Optional[dict],
+        contact_email: Optional[str],
+        photo_url: Optional[str],
+        metadata: Optional[dict],
+        display_order: int,
+    ) -> EventSpeaker:
+        speaker = EventSpeaker(
+            event_id=event_id,
+            full_name=full_name,
+            role=role,
+            title=title,
+            company=company,
+            bio=bio,
+            topics=topics,
+            contact_email=contact_email,
+            photo_url=photo_url,
+            metadata=metadata,
+            display_order=display_order,
+        )
+        self.session.add(speaker)
+        self.session.flush()
+        self.session.refresh(speaker)
+        return speaker
+
+    def list_for_event(self, event_id: int, *, role: Optional[str] = None) -> Sequence[EventSpeaker]:
+        query = select(EventSpeaker).where(EventSpeaker.event_id == event_id)
+        if role:
+            query = query.where(EventSpeaker.role == role)
+        query = query.order_by(EventSpeaker.display_order.asc(), EventSpeaker.full_name.asc())
+        return self.session.scalars(query).all()
+
+    def get(self, event_id: int, speaker_id: int) -> EventSpeaker:
+        speaker = self.session.get(EventSpeaker, speaker_id)
+        if speaker is None or speaker.event_id != event_id:
+            raise LookupError(f"Speaker {speaker_id} introuvable pour l'événement {event_id}")
+        return speaker
+
+    def update(self, speaker: EventSpeaker, updates: dict) -> EventSpeaker:
+        for key, value in updates.items():
+            setattr(speaker, key, value)
+        self.session.flush()
+        self.session.refresh(speaker)
+        return speaker
+
+    def delete(self, speaker: EventSpeaker) -> None:
+        self.session.delete(speaker)
+
+
+class EventSponsorRepository:
+    """Persistence layer for event sponsors."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def create(
+        self,
+        *,
+        event_id: int,
+        name: str,
+        level: Optional[str],
+        description: Optional[str],
+        website: Optional[str],
+        logo_url: Optional[str],
+        contact_email: Optional[str],
+        metadata: Optional[dict],
+        display_order: int,
+    ) -> EventSponsor:
+        sponsor = EventSponsor(
+            event_id=event_id,
+            name=name,
+            level=level,
+            description=description,
+            website=website,
+            logo_url=logo_url,
+            contact_email=contact_email,
+            metadata=metadata,
+            display_order=display_order,
+        )
+        self.session.add(sponsor)
+        self.session.flush()
+        self.session.refresh(sponsor)
+        return sponsor
+
+    def list_for_event(self, event_id: int) -> Sequence[EventSponsor]:
+        query = (
+            select(EventSponsor)
+            .where(EventSponsor.event_id == event_id)
+            .order_by(EventSponsor.display_order.asc(), EventSponsor.name.asc())
+        )
+        return self.session.scalars(query).all()
+
+    def get(self, event_id: int, sponsor_id: int) -> EventSponsor:
+        sponsor = self.session.get(EventSponsor, sponsor_id)
+        if sponsor is None or sponsor.event_id != event_id:
+            raise LookupError(f"Sponsor {sponsor_id} introuvable pour l'événement {event_id}")
+        return sponsor
+
+    def update(self, sponsor: EventSponsor, updates: dict) -> EventSponsor:
+        for key, value in updates.items():
+            setattr(sponsor, key, value)
+        self.session.flush()
+        self.session.refresh(sponsor)
+        return sponsor
+
+    def delete(self, sponsor: EventSponsor) -> None:
+        self.session.delete(sponsor)

--- a/src/routes/dependencies.py
+++ b/src/routes/dependencies.py
@@ -13,6 +13,9 @@ from src.services.events import (
     TagService,
     TemplateService,
 )
+from src.services.feedback import FeedbackService
+from src.services.networking import NetworkingService
+from src.services.participants import SpeakerService, SponsorService
 from src.services.recommendations import RecommendationService
 from src.services.search import EventSearchService
 
@@ -24,6 +27,10 @@ SERVICE_FACTORIES: Dict[str, Callable[[Any], Any]] = {
     "tag_service": TagService,
     "series_service": SeriesService,
     "template_service": TemplateService,
+    "networking_service": NetworkingService,
+    "feedback_service": FeedbackService,
+    "speaker_service": SpeakerService,
+    "sponsor_service": SponsorService,
 }
 
 EXTRA_SERVICE_KEYS = {"search_service", "recommendation_service"}
@@ -53,6 +60,22 @@ def get_series_service() -> SeriesService:
 
 def get_template_service() -> TemplateService:
     return _get_service("template_service", TemplateService)
+
+
+def get_networking_service() -> NetworkingService:
+    return _get_service("networking_service", NetworkingService)
+
+
+def get_feedback_service() -> FeedbackService:
+    return _get_service("feedback_service", FeedbackService)
+
+
+def get_speaker_service() -> SpeakerService:
+    return _get_service("speaker_service", SpeakerService)
+
+
+def get_sponsor_service() -> SponsorService:
+    return _get_service("sponsor_service", SponsorService)
 
 
 def get_search_service() -> EventSearchService:

--- a/src/services/events.py
+++ b/src/services/events.py
@@ -182,6 +182,13 @@ class EventService:
             attendees=clean_payload.get("attendees", 0),
             timezone=clean_payload.get("timezone", "UTC"),
             status=clean_payload.get("status", "draft"),
+            event_format=clean_payload.get("event_format", "in_person"),
+            streaming_url=clean_payload.get("streaming_url"),
+            virtual_platform=clean_payload.get("virtual_platform"),
+            virtual_access_instructions=clean_payload.get("virtual_access_instructions"),
+            secure_access_token=clean_payload.get("secure_access_token"),
+            rtmp_ingest_url=clean_payload.get("rtmp_ingest_url"),
+            rtmp_stream_key=clean_payload.get("rtmp_stream_key"),
             capacity_limit=clean_payload.get("capacity_limit"),
             recurrence_rule=clean_payload.get("recurrence_rule"),
             default_locale=clean_payload.get("default_locale", "fr"),
@@ -239,6 +246,13 @@ class EventService:
             "event_date",
             "timezone",
             "status",
+            "event_format",
+            "streaming_url",
+            "virtual_platform",
+            "virtual_access_instructions",
+            "secure_access_token",
+            "rtmp_ingest_url",
+            "rtmp_stream_key",
             "capacity_limit",
             "recurrence_rule",
             "default_locale",
@@ -511,6 +525,71 @@ class EventService:
             else:
                 clean["status"] = status
 
+        if "format" in data or require_title:
+            event_format = data.get("format", "in_person")
+            if event_format not in {"in_person", "virtual", "hybrid"}:
+                errors.setdefault("format", []).append("Format d'événement invalide.")
+            else:
+                clean["event_format"] = event_format
+
+        if "streaming_url" in data:
+            streaming_url = data.get("streaming_url")
+            if streaming_url is None:
+                clean["streaming_url"] = None
+            elif not isinstance(streaming_url, str) or not streaming_url.strip():
+                errors.setdefault("streaming_url", []).append("URL de streaming invalide.")
+            else:
+                clean["streaming_url"] = streaming_url.strip()
+
+        if "virtual_platform" in data:
+            platform = data.get("virtual_platform")
+            if platform is None:
+                clean["virtual_platform"] = None
+            elif not isinstance(platform, str) or not platform.strip():
+                errors.setdefault("virtual_platform", []).append("Plateforme virtuelle invalide.")
+            else:
+                clean["virtual_platform"] = platform.strip()
+
+        if "virtual_access_instructions" in data:
+            instructions = data.get("virtual_access_instructions")
+            if instructions is None:
+                clean["virtual_access_instructions"] = None
+            elif not isinstance(instructions, str) or not instructions.strip():
+                errors.setdefault("virtual_access_instructions", []).append(
+                    "Instructions d'accès invalides."
+                )
+            else:
+                clean["virtual_access_instructions"] = instructions.strip()
+
+        if "secure_access_token" in data:
+            token = data.get("secure_access_token")
+            if token is None:
+                clean["secure_access_token"] = None
+            elif not isinstance(token, str) or not token.strip():
+                errors.setdefault("secure_access_token", []).append(
+                    "Jeton d'accès sécurisé invalide."
+                )
+            else:
+                clean["secure_access_token"] = token.strip()
+
+        if "rtmp_ingest_url" in data:
+            ingest_url = data.get("rtmp_ingest_url")
+            if ingest_url is None:
+                clean["rtmp_ingest_url"] = None
+            elif not isinstance(ingest_url, str) or not ingest_url.strip():
+                errors.setdefault("rtmp_ingest_url", []).append("URL RTMP invalide.")
+            else:
+                clean["rtmp_ingest_url"] = ingest_url.strip()
+
+        if "rtmp_stream_key" in data:
+            stream_key = data.get("rtmp_stream_key")
+            if stream_key is None:
+                clean["rtmp_stream_key"] = None
+            elif not isinstance(stream_key, str) or not stream_key.strip():
+                errors.setdefault("rtmp_stream_key", []).append("Clé RTMP invalide.")
+            else:
+                clean["rtmp_stream_key"] = stream_key.strip()
+
         if "capacity_limit" in data:
             capacity = data.get("capacity_limit")
             if capacity is None:
@@ -758,6 +837,13 @@ class EventService:
             "attendees": payload.get("attendees", 0),
             "timezone": payload.get("timezone") or template.default_timezone,
             "status": payload.get("status", "draft"),
+            "format": payload.get("format") or "in_person",
+            "streaming_url": payload.get("streaming_url"),
+            "virtual_platform": payload.get("virtual_platform"),
+            "virtual_access_instructions": payload.get("virtual_access_instructions"),
+            "secure_access_token": payload.get("secure_access_token"),
+            "rtmp_ingest_url": payload.get("rtmp_ingest_url"),
+            "rtmp_stream_key": payload.get("rtmp_stream_key"),
             "capacity_limit": payload.get("capacity_limit", template.default_capacity_limit),
             "recurrence_rule": payload.get("recurrence_rule"),
             "default_locale": payload.get("default_locale", template.default_locale),
@@ -854,6 +940,13 @@ class EventService:
             "attendees": event.attendees,
             "timezone": event.timezone,
             "status": event.status,
+            "format": event.event_format,
+            "streaming_url": event.streaming_url,
+            "virtual_platform": event.virtual_platform,
+            "virtual_access_instructions": event.virtual_access_instructions,
+            "secure_access_token": event.secure_access_token,
+            "rtmp_ingest_url": event.rtmp_ingest_url,
+            "rtmp_stream_key": event.rtmp_stream_key,
             "capacity_limit": event.capacity_limit,
             "recurrence_rule": event.recurrence_rule,
             "default_locale": event.default_locale,

--- a/src/services/feedback.py
+++ b/src/services/feedback.py
@@ -1,0 +1,177 @@
+"""Service layer handling event feedback collection and moderation."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from src.repositories.events import EventRepository
+from src.repositories.feedback import FeedbackRepository
+
+__all__ = ["FeedbackService", "FeedbackValidationError", "FeedbackNotFoundError"]
+
+
+class FeedbackValidationError(Exception):
+    """Raised when feedback payload validation fails."""
+
+    def __init__(self, errors: Dict[str, List[str]], message: str = "Validation échouée."):
+        super().__init__(message)
+        self.errors = errors
+        self.message = message
+
+
+class FeedbackNotFoundError(Exception):
+    """Raised when a feedback entry is missing."""
+
+
+class FeedbackService:
+    """Collect attendee feedback and compute quality metrics."""
+
+    ALLOWED_STATUSES = {"pending", "approved", "rejected"}
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+        self.event_repository = EventRepository(session)
+        self.repository = FeedbackRepository(session)
+
+    def submit_feedback(self, event_id: int, payload: Dict[str, Any]) -> Dict[str, Any]:
+        self._ensure_event_exists(event_id)
+        clean = self._validate_submission_payload(payload)
+        feedback = self.repository.create(event_id=event_id, **clean)
+        self.session.commit()
+        return self._serialize_feedback(feedback)
+
+    def list_feedback(self, event_id: int) -> Dict[str, Any]:
+        self._ensure_event_exists(event_id)
+        feedback_entries = self.repository.list_for_event(event_id)
+        aggregates = self.repository.aggregates(event_id)
+        return {
+            "feedback": [self._serialize_feedback(entry) for entry in feedback_entries],
+            "summary": {
+                "total": aggregates["total"],
+                "average_rating": round(aggregates["average"], 2) if aggregates["total"] else 0.0,
+                "ratings_breakdown": aggregates["breakdown"],
+                "pending": aggregates["pending"],
+            },
+        }
+
+    def moderate_feedback(
+        self, event_id: int, feedback_id: int, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        self._ensure_event_exists(event_id)
+        feedback = self._get_feedback(event_id, feedback_id)
+        status, moderator = self._validate_moderation_payload(payload)
+        updated = self.repository.update_status(feedback, status=status, moderator=moderator)
+        self.session.commit()
+        return self._serialize_feedback(updated)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_event_exists(self, event_id: int) -> None:
+        try:
+            self.event_repository.get_event(event_id)
+        except LookupError as exc:
+            raise FeedbackNotFoundError(str(exc)) from exc
+
+    def _get_feedback(self, event_id: int, feedback_id: int):
+        try:
+            return self.repository.get(event_id, feedback_id)
+        except LookupError as exc:
+            raise FeedbackNotFoundError(str(exc)) from exc
+
+    def _validate_submission_payload(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(data, dict):
+            raise FeedbackValidationError(
+                {"_schema": ["Payload JSON invalide: un objet est requis."]}
+            )
+
+        errors: Dict[str, List[str]] = {}
+        clean: Dict[str, Any] = {}
+
+        rating = data.get("rating")
+        if isinstance(rating, int) and 1 <= rating <= 5:
+            clean["rating"] = rating
+        else:
+            errors.setdefault("rating", []).append("Note comprise entre 1 et 5 requise.")
+
+        comment = data.get("comment")
+        if comment is None or isinstance(comment, str):
+            clean["comment"] = comment.strip() if isinstance(comment, str) and comment.strip() else comment
+        else:
+            errors.setdefault("comment", []).append("Commentaire invalide.")
+
+        if "email" in data:
+            email = data.get("email")
+            if email is None:
+                clean["participant_email"] = None
+            elif isinstance(email, str) and email.strip():
+                clean["participant_email"] = email.strip().lower()
+            else:
+                errors.setdefault("email", []).append("Email invalide.")
+
+        if "name" in data:
+            name = data.get("name")
+            if name is None:
+                clean["participant_name"] = None
+            elif isinstance(name, str) and name.strip():
+                clean["participant_name"] = name.strip()
+            else:
+                errors.setdefault("name", []).append("Nom invalide.")
+
+        if "sentiment" in data:
+            sentiment = data.get("sentiment")
+            if sentiment is None or isinstance(sentiment, str):
+                clean["sentiment"] = sentiment.strip() if isinstance(sentiment, str) else sentiment
+            else:
+                errors.setdefault("sentiment", []).append("Champ sentiment invalide.")
+
+        metadata = data.get("metadata")
+        if metadata is not None:
+            if isinstance(metadata, dict):
+                clean["metadata"] = metadata
+            else:
+                errors.setdefault("metadata", []).append("Métadonnées invalides.")
+        else:
+            clean["metadata"] = None
+
+        if errors:
+            raise FeedbackValidationError(errors)
+
+        return clean
+
+    def _validate_moderation_payload(self, data: Dict[str, Any]) -> Tuple[str, Optional[str]]:
+        if not isinstance(data, dict):
+            raise FeedbackValidationError(
+                {"_schema": ["Payload JSON invalide: un objet est requis."]}
+            )
+
+        errors: Dict[str, List[str]] = {}
+        status = data.get("status")
+        if status not in self.ALLOWED_STATUSES:
+            errors.setdefault("status", []).append("Statut de modération invalide.")
+
+        moderator = data.get("moderator")
+        if moderator is not None and (not isinstance(moderator, str) or not moderator.strip()):
+            errors.setdefault("moderator", []).append("Nom du modérateur invalide.")
+        clean_moderator = moderator.strip() if isinstance(moderator, str) and moderator.strip() else None
+
+        if errors:
+            raise FeedbackValidationError(errors)
+        return status, clean_moderator
+
+    def _serialize_feedback(self, feedback) -> Dict[str, Any]:
+        return {
+            "id": feedback.id,
+            "event_id": feedback.event_id,
+            "email": feedback.participant_email,
+            "name": feedback.participant_name,
+            "rating": feedback.rating,
+            "comment": feedback.comment,
+            "sentiment": feedback.sentiment,
+            "status": feedback.status,
+            "metadata": feedback.metadata or {},
+            "moderated_by": feedback.moderated_by,
+            "moderated_at": feedback.moderated_at.isoformat() if feedback.moderated_at else None,
+            "created_at": feedback.created_at.isoformat(),
+        }

--- a/src/services/networking.py
+++ b/src/services/networking.py
@@ -1,0 +1,342 @@
+"""Networking orchestration service for participant matchmaking."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from sqlalchemy.orm import Session
+
+from src.models import ParticipantProfile
+from src.repositories.events import EventRepository
+from src.repositories.networking import (
+    NetworkingSuggestionRepository,
+    ParticipantProfileRepository,
+)
+
+__all__ = ["NetworkingService", "NetworkingValidationError", "ProfileNotFoundError"]
+
+
+class NetworkingValidationError(Exception):
+    """Raised when networking payload validation fails."""
+
+    def __init__(self, errors: Dict[str, List[str]], message: str = "Validation échouée."):
+        super().__init__(message)
+        self.errors = errors
+        self.message = message
+
+
+class ProfileNotFoundError(Exception):
+    """Raised when a participant profile could not be located."""
+
+
+class NetworkingService:
+    """Coordinate networking profile ingestion and matchmaking."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+        self.event_repository = EventRepository(session)
+        self.profile_repository = ParticipantProfileRepository(session)
+        self.suggestion_repository = NetworkingSuggestionRepository(session)
+
+    # ------------------------------------------------------------------
+    # Profile management
+    # ------------------------------------------------------------------
+    def register_profile(self, event_id: int, payload: Dict[str, Any]) -> Dict[str, Any]:
+        self._ensure_event_exists(event_id)
+        clean = self._validate_profile_payload(payload)
+
+        profile = self.profile_repository.upsert(
+            event_id=event_id,
+            attendee_email=clean["attendee_email"],
+            attendee_name=clean.get("attendee_name"),
+            company=clean.get("company"),
+            bio=clean.get("bio"),
+            headline=clean.get("headline"),
+            interests=clean.get("interests"),
+            goals=clean.get("goals"),
+            availability=clean.get("availability"),
+            metadata=clean.get("metadata"),
+        )
+
+        self.session.commit()
+        return self._serialize_profile(profile)
+
+    def list_profiles(self, event_id: int) -> List[Dict[str, Any]]:
+        self._ensure_event_exists(event_id)
+        profiles = self.profile_repository.list_for_event(event_id)
+        return [self._serialize_profile(profile) for profile in profiles]
+
+    # ------------------------------------------------------------------
+    # Suggestion workflow
+    # ------------------------------------------------------------------
+    def generate_suggestions(
+        self,
+        event_id: int,
+        *,
+        participant_email: Optional[str] = None,
+        limit: int = 3,
+    ) -> List[Dict[str, Any]]:
+        if limit is not None and limit < 0:
+            raise NetworkingValidationError({"limit": ["Doit être positif."]})
+
+        self._ensure_event_exists(event_id)
+        profiles = list(self.profile_repository.list_for_event(event_id))
+        if not profiles:
+            return []
+
+        if participant_email:
+            target = next(
+                (p for p in profiles if p.attendee_email == participant_email),
+                None,
+            )
+            if target is None:
+                raise ProfileNotFoundError(
+                    f"Profil {participant_email} introuvable pour l'événement {event_id}"
+                )
+            targets = [target]
+        else:
+            targets = profiles
+
+        for profile in targets:
+            ranked = self._rank_candidates(profile, profiles)
+            capped = ranked if limit is None else ranked[:limit]
+            for score, rationale, metadata, candidate in capped:
+                self.suggestion_repository.upsert(
+                    event_id=event_id,
+                    participant_id=profile.id,
+                    suggested_participant_id=candidate.id,
+                    score=score,
+                    rationale=rationale,
+                    metadata=metadata,
+                    status="pending",
+                )
+
+        self.session.commit()
+
+        if participant_email:
+            stored = self.suggestion_repository.list_for_participant(targets[0].id)
+        else:
+            stored = self.suggestion_repository.list_for_event(event_id)
+        return [self._serialize_suggestion(s) for s in stored]
+
+    def list_suggestions(
+        self, event_id: int, *, participant_email: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        self._ensure_event_exists(event_id)
+        if participant_email:
+            profile = self.profile_repository.get_by_event_and_email(event_id, participant_email)
+            if profile is None:
+                raise ProfileNotFoundError(
+                    f"Profil {participant_email} introuvable pour l'événement {event_id}"
+                )
+            suggestions = self.suggestion_repository.list_for_participant(profile.id)
+        else:
+            suggestions = self.suggestion_repository.list_for_event(event_id)
+        return [self._serialize_suggestion(s) for s in suggestions]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_event_exists(self, event_id: int) -> None:
+        try:
+            self.event_repository.get_event(event_id)
+        except LookupError as exc:
+            raise ProfileNotFoundError(str(exc)) from exc
+
+    def _validate_profile_payload(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(data, dict):
+            raise NetworkingValidationError(
+                {"_schema": ["Payload JSON invalide: un objet est attendu."]}
+            )
+
+        errors: Dict[str, List[str]] = {}
+        clean: Dict[str, Any] = {}
+
+        email = data.get("email")
+        if not isinstance(email, str) or not email.strip():
+            errors.setdefault("email", []).append("Adresse email requise.")
+        else:
+            clean["attendee_email"] = email.strip().lower()
+
+        if "name" in data:
+            name = data.get("name")
+            if name is None:
+                clean["attendee_name"] = None
+            elif not isinstance(name, str) or not name.strip():
+                errors.setdefault("name", []).append("Nom invalide.")
+            else:
+                clean["attendee_name"] = name.strip()
+
+        if "company" in data:
+            company = data.get("company")
+            clean["company"] = company.strip() if isinstance(company, str) else company
+
+        if "bio" in data:
+            bio = data.get("bio")
+            if bio is None or isinstance(bio, str):
+                clean["bio"] = bio
+            else:
+                errors.setdefault("bio", []).append("Bio invalide.")
+
+        if "headline" in data:
+            headline = data.get("headline")
+            if headline is None or isinstance(headline, str):
+                clean["headline"] = headline.strip() if isinstance(headline, str) else None
+            else:
+                errors.setdefault("headline", []).append("Entête invalide.")
+
+        if "interests" in data:
+            interests = self._sanitize_string_list(data.get("interests"), "interests")
+            if interests is not None:
+                clean["interests"] = {"items": interests}
+            else:
+                errors.setdefault("interests", []).append("Liste d'intérêts invalide.")
+
+        if "goals" in data:
+            goals = self._sanitize_string_list(data.get("goals"), "goals")
+            if goals is not None:
+                clean["goals"] = {"items": goals}
+            else:
+                errors.setdefault("goals", []).append("Objectifs invalides.")
+
+        if "availability" in data:
+            availability = self._sanitize_string_list(data.get("availability"), "availability")
+            if availability is not None:
+                clean["availability"] = {"slots": availability}
+            else:
+                errors.setdefault("availability", []).append("Plages horaires invalides.")
+
+        metadata = data.get("metadata")
+        if metadata is not None:
+            if isinstance(metadata, dict):
+                clean["metadata"] = metadata
+            else:
+                errors.setdefault("metadata", []).append("Métadonnées invalides.")
+
+        if errors:
+            raise NetworkingValidationError(errors)
+
+        return clean
+
+    def _sanitize_string_list(self, value: Any, field: str) -> Optional[List[str]]:
+        if value is None:
+            return []
+        if isinstance(value, dict):
+            if "items" in value and isinstance(value["items"], Iterable):
+                value = value["items"]
+            elif "slots" in value and isinstance(value["slots"], Iterable):
+                value = value["slots"]
+            else:
+                return None
+        if not isinstance(value, Iterable) or isinstance(value, (str, bytes)):
+            return None
+        cleaned: List[str] = []
+        for entry in value:
+            if not isinstance(entry, str):
+                continue
+            normalized = entry.strip()
+            if normalized and normalized not in cleaned:
+                cleaned.append(normalized)
+        return cleaned
+
+    def _rank_candidates(
+        self,
+        profile: ParticipantProfile,
+        candidates: Sequence[ParticipantProfile],
+    ) -> List[Tuple[float, str, Dict[str, Any], ParticipantProfile]]:
+        ranked: List[Tuple[float, str, Dict[str, Any], ParticipantProfile]] = []
+        for candidate in candidates:
+            if candidate.id == profile.id:
+                continue
+            score, rationale, metadata = self._score_pair(profile, candidate)
+            if score <= 0:
+                continue
+            ranked.append((score, rationale, metadata, candidate))
+        ranked.sort(key=lambda item: item[0], reverse=True)
+        return ranked
+
+    def _score_pair(
+        self, first: ParticipantProfile, second: ParticipantProfile
+    ) -> Tuple[float, str, Dict[str, Any]]:
+        first_interests = set(self._extract_list(first.interests, "items"))
+        second_interests = set(self._extract_list(second.interests, "items"))
+        shared_interests = sorted(first_interests & second_interests)
+
+        first_goals = set(self._extract_list(first.goals, "items"))
+        second_goals = set(self._extract_list(second.goals, "items"))
+        shared_goals = sorted(first_goals & second_goals)
+
+        first_slots = set(self._extract_list(first.availability, "slots"))
+        second_slots = set(self._extract_list(second.availability, "slots"))
+        shared_slots = sorted(first_slots & second_slots)
+
+        score = 0.0
+        if shared_interests:
+            score += len(shared_interests) * 2
+        if shared_goals:
+            score += len(shared_goals)
+        if shared_slots:
+            score += 1.5
+        if first.company and second.company:
+            if first.company.strip().lower() == second.company.strip().lower():
+                score *= 0.8  # prefer diversity between companies
+            else:
+                score += 0.5
+
+        rationale_parts: List[str] = []
+        if shared_interests:
+            rationale_parts.append(f"{len(shared_interests)} intérêts communs")
+        if shared_goals:
+            rationale_parts.append(f"{len(shared_goals)} objectifs alignés")
+        if shared_slots:
+            rationale_parts.append("disponibilités compatibles")
+        if not rationale_parts:
+            rationale_parts.append("complémentarité potentielle")
+
+        metadata = {
+            "shared_interests": shared_interests,
+            "shared_goals": shared_goals,
+            "shared_slots": shared_slots,
+        }
+        return score, ", ".join(rationale_parts), metadata
+
+    def _extract_list(self, container: Any, key: str) -> List[str]:
+        if isinstance(container, dict):
+            value = container.get(key, [])
+        else:
+            value = container or []
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        return []
+
+    def _serialize_profile(self, profile: ParticipantProfile) -> Dict[str, Any]:
+        return {
+            "id": profile.id,
+            "event_id": profile.event_id,
+            "email": profile.attendee_email,
+            "name": profile.attendee_name,
+            "company": profile.company,
+            "bio": profile.bio,
+            "headline": profile.headline,
+            "interests": self._extract_list(profile.interests, "items"),
+            "goals": self._extract_list(profile.goals, "items"),
+            "availability": self._extract_list(profile.availability, "slots"),
+            "metadata": profile.metadata or {},
+            "created_at": profile.created_at.isoformat(),
+        }
+
+    def _serialize_suggestion(self, suggestion) -> Dict[str, Any]:
+        participant = suggestion.participant
+        match = suggestion.suggested_participant
+        return {
+            "id": suggestion.id,
+            "event_id": suggestion.event_id,
+            "participant_email": participant.attendee_email if participant else None,
+            "participant_name": participant.attendee_name if participant else None,
+            "suggested_email": match.attendee_email if match else None,
+            "suggested_name": match.attendee_name if match else None,
+            "score": suggestion.score,
+            "status": suggestion.status,
+            "rationale": suggestion.rationale,
+            "metadata": suggestion.metadata or {},
+            "created_at": suggestion.created_at.isoformat(),
+        }

--- a/src/services/participants.py
+++ b/src/services/participants.py
@@ -1,0 +1,295 @@
+"""Services managing event speakers, organisers and sponsors."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from src.repositories.events import EventRepository
+from src.repositories.partners import EventSpeakerRepository, EventSponsorRepository
+
+__all__ = [
+    "SpeakerService",
+    "SpeakerValidationError",
+    "SpeakerNotFoundError",
+    "SponsorService",
+    "SponsorValidationError",
+    "SponsorNotFoundError",
+]
+
+
+class SpeakerValidationError(Exception):
+    def __init__(self, errors: Dict[str, List[str]], message: str = "Validation échouée."):
+        super().__init__(message)
+        self.errors = errors
+        self.message = message
+
+
+class SpeakerNotFoundError(Exception):
+    """Raised when a speaker or organiser cannot be located."""
+
+
+class SponsorValidationError(Exception):
+    def __init__(self, errors: Dict[str, List[str]], message: str = "Validation échouée."):
+        super().__init__(message)
+        self.errors = errors
+        self.message = message
+
+
+class SponsorNotFoundError(Exception):
+    """Raised when a sponsor cannot be located."""
+
+
+class SpeakerService:
+    """Handle CRUD operations for speakers and organisers."""
+
+    ALLOWED_ROLES = {"speaker", "organizer"}
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+        self.event_repository = EventRepository(session)
+        self.repository = EventSpeakerRepository(session)
+
+    def add_profile(self, event_id: int, payload: Dict[str, Any]) -> Dict[str, Any]:
+        self._ensure_event_exists(event_id)
+        clean = self._validate_payload(payload, require_name=True)
+        if clean.get("display_order") is None:
+            clean["display_order"] = self._next_display_order(event_id)
+        speaker = self.repository.create(event_id=event_id, **clean)
+        self.session.commit()
+        return self._serialize_speaker(speaker)
+
+    def update_profile(
+        self, event_id: int, speaker_id: int, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        self._ensure_event_exists(event_id)
+        speaker = self._get_speaker(event_id, speaker_id)
+        clean = self._validate_payload(payload, require_name=False)
+        if not clean:
+            return self._serialize_speaker(speaker)
+        updated = self.repository.update(speaker, clean)
+        self.session.commit()
+        return self._serialize_speaker(updated)
+
+    def remove_profile(self, event_id: int, speaker_id: int) -> None:
+        self._ensure_event_exists(event_id)
+        speaker = self._get_speaker(event_id, speaker_id)
+        self.repository.delete(speaker)
+        self.session.commit()
+
+    def list_profiles(self, event_id: int, role: Optional[str] = None) -> List[Dict[str, Any]]:
+        self._ensure_event_exists(event_id)
+        speakers = self.repository.list_for_event(event_id, role=role)
+        return [self._serialize_speaker(speaker) for speaker in speakers]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_event_exists(self, event_id: int) -> None:
+        try:
+            self.event_repository.get_event(event_id)
+        except LookupError as exc:
+            raise SpeakerNotFoundError(str(exc)) from exc
+
+    def _get_speaker(self, event_id: int, speaker_id: int):
+        try:
+            return self.repository.get(event_id, speaker_id)
+        except LookupError as exc:
+            raise SpeakerNotFoundError(str(exc)) from exc
+
+    def _validate_payload(self, data: Dict[str, Any], *, require_name: bool) -> Dict[str, Any]:
+        if not isinstance(data, dict):
+            raise SpeakerValidationError(
+                {"_schema": ["Payload JSON invalide: un objet est requis."]}
+            )
+        errors: Dict[str, List[str]] = {}
+        clean: Dict[str, Any] = {}
+
+        if "name" in data or require_name:
+            name = data.get("name")
+            if not isinstance(name, str) or not name.strip():
+                errors.setdefault("name", []).append("Nom complet requis.")
+            else:
+                clean["full_name"] = name.strip()
+
+        if "role" in data:
+            role = data.get("role")
+            if role not in self.ALLOWED_ROLES:
+                errors.setdefault("role", []).append("Type d'intervenant invalide.")
+            else:
+                clean["role"] = role
+
+        for field in ["title", "company", "bio", "contact_email", "photo_url"]:
+            if field in data:
+                value = data.get(field)
+                if value is None or isinstance(value, str):
+                    clean[field] = value.strip() if isinstance(value, str) and value.strip() else value
+                else:
+                    errors.setdefault(field, []).append("Valeur invalide.")
+
+        if "topics" in data:
+            topics = data.get("topics")
+            if topics is None or isinstance(topics, dict):
+                clean["topics"] = topics
+            else:
+                errors.setdefault("topics", []).append("Thématiques invalides.")
+
+        if "metadata" in data:
+            metadata = data.get("metadata")
+            if metadata is None or isinstance(metadata, dict):
+                clean["metadata"] = metadata
+            else:
+                errors.setdefault("metadata", []).append("Métadonnées invalides.")
+
+        if "display_order" in data:
+            order = data.get("display_order")
+            if isinstance(order, int) and order >= 0:
+                clean["display_order"] = order
+            else:
+                errors.setdefault("display_order", []).append("Ordre d'affichage invalide.")
+
+        if errors:
+            raise SpeakerValidationError(errors)
+
+        return clean
+
+    def _next_display_order(self, event_id: int) -> int:
+        speakers = self.repository.list_for_event(event_id)
+        if not speakers:
+            return 0
+        return max(s.display_order for s in speakers) + 1
+
+    def _serialize_speaker(self, speaker) -> Dict[str, Any]:
+        return {
+            "id": speaker.id,
+            "event_id": speaker.event_id,
+            "name": speaker.full_name,
+            "role": speaker.role,
+            "title": speaker.title,
+            "company": speaker.company,
+            "bio": speaker.bio,
+            "topics": speaker.topics or {},
+            "contact_email": speaker.contact_email,
+            "photo_url": speaker.photo_url,
+            "metadata": speaker.metadata or {},
+            "display_order": speaker.display_order,
+            "created_at": speaker.created_at.isoformat(),
+        }
+
+
+class SponsorService:
+    """Handle sponsor management workflows."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+        self.event_repository = EventRepository(session)
+        self.repository = EventSponsorRepository(session)
+
+    def add_sponsor(self, event_id: int, payload: Dict[str, Any]) -> Dict[str, Any]:
+        self._ensure_event_exists(event_id)
+        clean = self._validate_payload(payload)
+        if clean.get("display_order") is None:
+            clean["display_order"] = self._next_display_order(event_id)
+        sponsor = self.repository.create(event_id=event_id, **clean)
+        self.session.commit()
+        return self._serialize_sponsor(sponsor)
+
+    def update_sponsor(
+        self, event_id: int, sponsor_id: int, payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        self._ensure_event_exists(event_id)
+        sponsor = self._get_sponsor(event_id, sponsor_id)
+        clean = self._validate_payload(payload, partial=True)
+        if not clean:
+            return self._serialize_sponsor(sponsor)
+        updated = self.repository.update(sponsor, clean)
+        self.session.commit()
+        return self._serialize_sponsor(updated)
+
+    def remove_sponsor(self, event_id: int, sponsor_id: int) -> None:
+        self._ensure_event_exists(event_id)
+        sponsor = self._get_sponsor(event_id, sponsor_id)
+        self.repository.delete(sponsor)
+        self.session.commit()
+
+    def list_sponsors(self, event_id: int) -> List[Dict[str, Any]]:
+        self._ensure_event_exists(event_id)
+        sponsors = self.repository.list_for_event(event_id)
+        return [self._serialize_sponsor(sponsor) for sponsor in sponsors]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_event_exists(self, event_id: int) -> None:
+        try:
+            self.event_repository.get_event(event_id)
+        except LookupError as exc:
+            raise SponsorNotFoundError(str(exc)) from exc
+
+    def _get_sponsor(self, event_id: int, sponsor_id: int):
+        try:
+            return self.repository.get(event_id, sponsor_id)
+        except LookupError as exc:
+            raise SponsorNotFoundError(str(exc)) from exc
+
+    def _validate_payload(self, data: Dict[str, Any], partial: bool = False) -> Dict[str, Any]:
+        if not isinstance(data, dict):
+            raise SponsorValidationError(
+                {"_schema": ["Payload JSON invalide: un objet est requis."]}
+            )
+        errors: Dict[str, List[str]] = {}
+        clean: Dict[str, Any] = {}
+
+        if "name" in data or not partial:
+            name = data.get("name")
+            if not isinstance(name, str) or not name.strip():
+                errors.setdefault("name", []).append("Nom du sponsor requis.")
+            else:
+                clean["name"] = name.strip()
+
+        for field in ["level", "description", "website", "logo_url", "contact_email"]:
+            if field in data:
+                value = data.get(field)
+                if value is None or isinstance(value, str):
+                    clean[field] = value.strip() if isinstance(value, str) and value.strip() else value
+                else:
+                    errors.setdefault(field, []).append("Valeur invalide.")
+
+        if "metadata" in data:
+            metadata = data.get("metadata")
+            if metadata is None or isinstance(metadata, dict):
+                clean["metadata"] = metadata
+            else:
+                errors.setdefault("metadata", []).append("Métadonnées invalides.")
+
+        if "display_order" in data:
+            order = data.get("display_order")
+            if isinstance(order, int) and order >= 0:
+                clean["display_order"] = order
+            else:
+                errors.setdefault("display_order", []).append("Ordre d'affichage invalide.")
+
+        if errors:
+            raise SponsorValidationError(errors)
+        return clean
+
+    def _next_display_order(self, event_id: int) -> int:
+        sponsors = self.repository.list_for_event(event_id)
+        if not sponsors:
+            return 0
+        return max(s.display_order for s in sponsors) + 1
+
+    def _serialize_sponsor(self, sponsor) -> Dict[str, Any]:
+        return {
+            "id": sponsor.id,
+            "event_id": sponsor.event_id,
+            "name": sponsor.name,
+            "level": sponsor.level,
+            "description": sponsor.description,
+            "website": sponsor.website,
+            "logo_url": sponsor.logo_url,
+            "contact_email": sponsor.contact_email,
+            "metadata": sponsor.metadata or {},
+            "display_order": sponsor.display_order,
+            "created_at": sponsor.created_at.isoformat(),
+        }


### PR DESCRIPTION
## Summary
- extend event models with virtual streaming metadata plus networking, feedback, speaker, and sponsor relationships
- add repositories, services, and API endpoints for participant networking, feedback aggregation, speakers/organisers, and sponsors
- integrate Flask-SocketIO with a safe fallback and expand end-to-end tests for the new flows

## Testing
- ⚠️ `pip install -r requirements.txt` *(fails: proxy prevented downloading Flask-SocketIO/SQLAlchemy)*
- ⚠️ `pytest` *(fails: SQLAlchemy missing because installation is blocked by the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a65cc2bc8332bb4883d771e25cfb